### PR TITLE
docs: update moonshot api url

### DIFF
--- a/docs/zh-cn/stage-2/backend/2.6-modern-cli/extra7/extra7-cli-ai-coding-tools-and-the-principles-of-test-driven-development.md
+++ b/docs/zh-cn/stage-2/backend/2.6-modern-cli/extra7/extra7-cli-ai-coding-tools-and-the-principles-of-test-driven-development.md
@@ -197,7 +197,7 @@ Kimi K2 是月之暗面（Moonshot AI）推出的新一代大语言模型，在�
 **配置方法：**
 
 ```Bash
-export ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic
+export ANTHROPIC_BASE_URL=https://api.moonshot.cn/anthropic
 export ANTHROPIC_AUTH_TOKEN=sk-YOURKEY
 ```
 


### PR DESCRIPTION
close https://github.com/datawhalechina/easy-vibe/issues/27

by the way
我发现国际化，很多文档都是404😂
比如，https://datawhalechina.github.io/easy-vibe/zh-tw/stage-2/backend/2.6-modern-cli/extra7/extra7-cli-ai-coding-tools-and-the-principles-of-test-driven-development.html