### PR TITLE
fix: 修正 find-skills 安装命令，改用正确仓库 vercel-labs/skills

### DIFF
--- a/docs/zh-cn/stage-3/core-skills/skills/index.md
+++ b/docs/zh-cn/stage-3/core-skills/skills/index.md
@@ -46,7 +46,7 @@ Skills 解决了这些问题，让 Claude 变成一个"有经验的团队成员"
 **安装 find-skills**：
 
 ```bash
-npx skills add vercel-labs/agent-skills@find-skills -g -y
+npx skills add vercel-labs/skills@find-skills -g -y
 ```
 
 安装完成后，你就可以直接告诉 Claude 你的需求，它会通过 find-skills 自动搜索相关技能。


### PR DESCRIPTION
原命令使用 vercel-labs/agent-skills@find-skills 会导致 No matching skills found，因为 find-skills 实际在 vercel-labs/skills 仓库。
修正为 vercel-labs/skills@find-skills。