### PR TITLE
docs: add MiniMax as alternative text generation model option

### DIFF
--- a/docs/en/stage-1/1.3-integrating-ai-capabilities/index.md
+++ b/docs/en/stage-1/1.3-integrating-ai-capabilities/index.md
@@ -161,6 +161,57 @@ Of course, you might be wondering: how do I know it's actually calling the large
 
 If you find that the results are different each time and logically coherent, you can be confident that the API is being called correctly. You can also check the [API usage management platform](https://platform.deepseek.com/usage) to see if the calls were successful (though it may take a few minutes to show up).
 
+## More Text Generation Model Options
+
+In addition to DeepSeek, you can also try other large language models. Since most models provide an **OpenAI-compatible API**, switching is very simple — you only need to change the API Key, base URL, and model name.
+
+### MiniMax Integration
+
+::: details Learn More: What is MiniMax?
+
+**MiniMax** is a Chinese AI company dedicated to general artificial intelligence research. MiniMax has developed its own MiniMax-M2.5 series of large language models, which perform well in multiple benchmarks with excellent cost-effectiveness.
+
+**Key Features of MiniMax-M2.5 Series:**
+
+- **Ultra-long context**: Supports a 204,800-token context window, suitable for processing long documents and multi-turn conversations
+- **Cost-effective**: Input $0.3/M tokens, Output $1.2/M tokens, extremely competitive pricing
+- **OpenAI-compatible API**: Can be called directly using the OpenAI SDK, no need to learn a new API format
+- **Two available models**:
+  - `MiniMax-M2.5`: Flagship model for complex tasks
+  - `MiniMax-M2.5-highspeed`: High-speed version with same performance but faster response
+:::
+
+The integration process is the same as DeepSeek, just three steps:
+
+1. Go to [MiniMax Platform](https://platform.minimax.io/) to register and create an API Key
+2. Find the API call examples in MiniMax documentation
+3. Paste the API Key + example into your AI IDE
+
+Since MiniMax provides an OpenAI-compatible API, you can copy the following curl example along with your API Key and send it to your AI IDE for integration:
+
+```bash
+curl https://api.minimax.io/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${MINIMAX_API_KEY}" \
+  -d '{
+        "model": "MiniMax-M2.5",
+        "messages": [
+          {"role": "system", "content": "You are a helpful assistant."},
+          {"role": "user", "content": "Hello!"}
+        ],
+        "stream": false
+      }'
+```
+
+::: tip ✅ Tip
+MiniMax's API format is almost identical to DeepSeek (both are OpenAI-compatible), so if you've already successfully integrated DeepSeek, switching to MiniMax only requires changing three things:
+1. **Base URL**: Change to `https://api.minimax.io/v1`
+2. **API Key**: Use your MiniMax API Key
+3. **Model name**: Change to `MiniMax-M2.5` or `MiniMax-M2.5-highspeed`
+
+For more details, refer to the [MiniMax OpenAI Compatible API Documentation](https://platform.minimax.io/docs/api-reference/text-openai-api).
+:::
+
 # 3. Integrating the Image-to-Text API: Qwen3 VL
 
 ::: info ℹ️ Further Reading on Principles

--- a/docs/zh-cn/appendix/8-artificial-intelligence/ai-capability-dictionary.md
+++ b/docs/zh-cn/appendix/8-artificial-intelligence/ai-capability-dictionary.md
@@ -49,7 +49,7 @@
 > - OpenAI 系列：GPT-4、GPT-4.1、GPT-4o、GPT-5.1 等
 > - Google 系列：Gemini 1.5 Pro、Gemini 1.5 Flash 等
 > - Anthropic 系列：Claude 3.5 Sonnet、Claude 3.5 Haiku 等
-> - 国内模型：通义千问 Qwen 系列、文心一言 ERNIE Bot 系列、GLM/智谱清言、腾讯混元、讯飞星火、月之暗面的 Kimi 背后的大模型等
+> - 国内模型：通义千问 Qwen 系列、文心一言 ERNIE Bot 系列、GLM/智谱清言、腾讯混元、讯飞星火、月之暗面的 Kimi 背后的大模型、MiniMax MiniMax-M2.5 系列等
 >
 > 更偏视觉和视频方向的大模型和服务，包括：
 >

--- a/docs/zh-cn/stage-1/1.3-integrating-ai-capabilities/index.md
+++ b/docs/zh-cn/stage-1/1.3-integrating-ai-capabilities/index.md
@@ -161,6 +161,57 @@ curl  \
 
 如果发现每次不一样并且合乎逻辑，你可以放心认为此时已经正常调用 API 生成。你也可以在 [API 使用管理平台](https://platform.deepseek.com/usage)查看是否成功调用（虽然可能需要等几分钟才能看到）。
 
+## 更多文本生成模型选型
+
+除了 DeepSeek 之外，你也可以尝试其他大语言模型。由于大多数模型都提供了 **OpenAI 兼容接口**，切换起来非常简单——只需要更换 API Key、基础 URL 和模型名称即可。
+
+### MiniMax 集成
+
+::: details 了解更多：MiniMax 是什么？
+
+**MiniMax** 是一家中国人工智能公司，致力于通用人工智能技术的研发。MiniMax 推出了自研的 MiniMax-M2.5 大语言模型系列，在多项基准测试中表现优异，具有极高的性价比。
+
+**MiniMax-M2.5 系列的主要特点：**
+
+- **超长上下文**：支持 204,800 tokens 的上下文窗口，适合处理长文档、多轮对话
+- **高性价比**：输入 $0.3/M tokens，输出 $1.2/M tokens，价格极具竞争力
+- **OpenAI 兼容接口**：可以直接使用 OpenAI SDK 调用，无需额外学习新的 API 格式
+- **两个可用模型**：
+  - `MiniMax-M2.5`：旗舰模型，适合复杂任务
+  - `MiniMax-M2.5-highspeed`：高速版本，保持同样的性能但更快
+:::
+
+接入方式与 DeepSeek 一致，只需要三步：
+
+1. 前往 [MiniMax 开放平台](https://platform.minimax.io/) 注册账号并创建 API Key
+2. 在 MiniMax 文档中找到调用示例
+3. 把 API Key + 示例粘贴到 AI IDE 中
+
+由于 MiniMax 提供了 OpenAI 兼容接口，你可以直接复制下面的 curl 示例和你的 API Key，发给 AI IDE 进行集成：
+
+```bash
+curl https://api.minimax.io/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${MINIMAX_API_KEY}" \
+  -d '{
+        "model": "MiniMax-M2.5",
+        "messages": [
+          {"role": "system", "content": "You are a helpful assistant."},
+          {"role": "user", "content": "Hello!"}
+        ],
+        "stream": false
+      }'
+```
+
+::: tip ✅ 提示
+MiniMax 的 API 格式与 DeepSeek 几乎完全一致（都是 OpenAI 兼容格式），所以如果你已经成功接入了 DeepSeek，切换到 MiniMax 只需要修改三个地方：
+1. **基础 URL**：改为 `https://api.minimax.io/v1`
+2. **API Key**：使用 MiniMax 的 API Key
+3. **模型名称**：改为 `MiniMax-M2.5` 或 `MiniMax-M2.5-highspeed`
+
+更多信息请参考 [MiniMax OpenAI 兼容接口文档](https://platform.minimax.io/docs/api-reference/text-openai-api)。
+:::
+
 # 3. 接入图像转文字 API：Qwen3 VL
 
 ::: info ℹ️ 原理延伸


### PR DESCRIPTION
## Summary
Add MiniMax-M2.5 as an alternative text generation model option in the API integration tutorial, giving learners another high-quality, cost-effective LLM choice alongside DeepSeek.

## Changes
- **API Integration Tutorial (Chinese & English)**: Added a "更多文本生成模型选型 / More Text Generation Model Options" section after the DeepSeek tutorial, introducing MiniMax-M2.5 with:
  - Model introduction and key features (204K context window, competitive pricing)
  - OpenAI-compatible API curl example for easy integration
  - Quick switching guide (only 3 changes needed: base URL, API key, model name)
  - Links to official MiniMax documentation
- **AI Capability Dictionary**: Added MiniMax MiniMax-M2.5 to the list of domestic AI models

## Why MiniMax?
- **OpenAI-compatible API**: Same format as DeepSeek, making it trivial to switch
- **204,800 token context**: One of the largest context windows available
- **Cost-effective**: Input $0.3/M tokens, Output $1.2/M tokens
- **Two model variants**: MiniMax-M2.5 (flagship) and MiniMax-M2.5-highspeed (faster)

## API Documentation
- OpenAI Compatible: https://platform.minimax.io/docs/api-reference/text-openai-api