### PR TITLE
Add fork Pages ship-it flow and slide controls

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   PAGES_BASE: ${{ vars.PAGES_BASE || format('/{0}/', github.event.repository.name) }}
   PAGES_SITE_URL: ${{ vars.PAGES_SITE_URL || format('https://{0}.github.io/{1}', github.repository_owner, github.event.repository.name) }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,56 +1,64 @@
-# Sample workflow for building and deploying a VitePress site to GitHub Pages
 name: Deploy VitePress site to Pages
 
 on:
-  # Runs on pushes to main branch only
   push:
     branches:
       - main
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: pages
+  group: pages-${{ github.repository }}
   cancel-in-progress: false
 
+env:
+  PAGES_BASE: ${{ vars.PAGES_BASE || format('/{0}/', github.event.repository.name) }}
+  PAGES_SITE_URL: ${{ vars.PAGES_SITE_URL || format('https://{0}.github.io/{1}', github.repository_owner, github.event.repository.name) }}
+
 jobs:
-  # Build job
   build:
-    if: github.repository_owner == 'datawhalechina'
+    if: github.repository_owner == 'datawhalechina' || vars.ENABLE_PAGES_DEPLOY == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Not needed if lastUpdated is not enabled
+          fetch-depth: 0
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
+
       - name: Install dependencies
         run: npm ci
-      - name: Build with VitePress
+
+      - name: Show deployment target
         run: |
-          npm run build
+          echo "BASE=${PAGES_BASE}"
+          echo "SITE_URL=${PAGES_SITE_URL}"
+
+      - name: Build with VitePress
+        env:
+          BASE: ${{ env.PAGES_BASE }}
+          SITE_URL: ${{ env.PAGES_SITE_URL }}
+        run: npm run build
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
 
-  # Deployment job
   deploy:
+    if: github.repository_owner == 'datawhalechina' || vars.ENABLE_PAGES_DEPLOY == 'true'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ MULTI_LANGUAGE_PLAN.md
 .trae
 scripts/collapse_code_blocks.py
 .gitignore
-scripts/verify.sh
 REFACTORING_PLAN.md
 .gitignore
 .gitignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ npm install
 npm run dev      # start local docs server (hot reload)
 npm run build    # production build (use as CI-style check)
 npm run preview  # preview the built site locally
+npm run verify   # lint and production build without rewriting tracked sitemap
 npm run format   # run Prettier on the whole repo
 ```
 
@@ -39,3 +40,12 @@ There is no dedicated test framework in this repo. Use `npm run build` as the pr
 ## Configuration & Deployment Notes
 
 - `vercel.json` is present; keep builds reproducible and avoid relying on local-only assets.
+- GitHub Pages deploys from `.github/workflows/deploy.yml`. Upstream `datawhalechina/easy-vibe` deploys by default; forks must opt in with repo variable `ENABLE_PAGES_DEPLOY=true`.
+- Fork Pages builds should use `BASE=/<repo-name>/` and `SITE_URL=https://<owner>.github.io/<repo-name>` unless `PAGES_BASE` or `PAGES_SITE_URL` repo variables override them.
+
+## Ship-It Workflow
+
+- When the user says `ship it`, preserve unrelated dirty files and only stage the intended changes.
+- Run `npm run verify` before release. For UI/docs rendering changes, also run a local preview and verify the relevant flow in the official Codex in-app browser.
+- Release path is direct to the fork `main`: commit, push `origin main`, wait for `Deploy VitePress site to Pages`, then verify the live fork Pages URL `https://longbiaochen.github.io/easy-vibe/`.
+- After the fork Pages preview is verified, summarize the diff against `upstream/main` and ask explicitly before creating a PR to `datawhalechina/easy-vibe`. Do not open the upstream PR without that approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,5 +47,5 @@ There is no dedicated test framework in this repo. Use `npm run build` as the pr
 
 - When the user says `ship it`, preserve unrelated dirty files and only stage the intended changes.
 - Run `npm run verify` before release. For UI/docs rendering changes, also run a local preview and verify the relevant flow in the official Codex in-app browser.
-- Release path is direct to the fork `main`: commit, push `origin main`, wait for `Deploy VitePress site to Pages`, then verify the live fork Pages URL `https://longbiaochen.github.io/easy-vibe/`.
+- Release path is direct to the fork `main`: commit, push `origin main`, wait for `Deploy VitePress site to Pages`, then verify the live fork Pages URL `https://longbiaochen.github.io/easy-vibe/`. If no Pages run appears within 60 seconds after push, trigger the same workflow manually with `gh workflow run deploy.yml --repo longbiaochen/easy-vibe --ref main`.
 - After the fork Pages preview is verified, summarize the diff against `upstream/main` and ask explicitly before creating a PR to `datawhalechina/easy-vibe`. Do not open the upstream PR without that approval.

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -6,11 +6,21 @@ const isVercel = process.env.VERCEL === '1' || !!process.env.VERCEL_URL
 // 检查是否为 EdgeOne 部署 (通过环境变量 EDGEONE 判断)
 const isEdgeOne = !!process.env.EDGEONE || process.env.EDGEONE === '1'
 
+const normalizeBase = (value) => {
+  if (!value || value === '/') return '/'
+  const withLeadingSlash = value.startsWith('/') ? value : `/${value}`
+  return withLeadingSlash.endsWith('/')
+    ? withLeadingSlash
+    : `${withLeadingSlash}/`
+}
+
 // 确定 Base 路径：
 // 1. 如果设置了 BASE 环境变量，优先使用
 // 2. 如果是 Vercel 或 EdgeOne，默认使用根路径 '/'
 // 3. 否则（如 GitHub Pages），使用 '/easy-vibe/'
-const base = process.env.BASE || (isVercel || isEdgeOne ? '/' : '/easy-vibe/')
+const base = normalizeBase(
+  process.env.BASE || (isVercel || isEdgeOne ? '/' : '/easy-vibe/')
+)
 
 // 站点 URL 配置 - 根据部署环境动态确定
 const getSiteUrl = () => {
@@ -26,7 +36,26 @@ const getSiteUrl = () => {
   return 'https://datawhalechina.github.io/easy-vibe'
 }
 
-const siteUrl = getSiteUrl()
+const siteUrl = getSiteUrl().replace(/\/+$/, '')
+
+const siteAssetUrl = (assetPath) => {
+  return `${siteUrl}/${assetPath.replace(/^\/+/, '')}`
+}
+
+const withBasePath = (urlPath) => {
+  if (/^https?:\/\//.test(urlPath)) return urlPath
+  if (urlPath === '') return base
+
+  const pathWithLeadingSlash = urlPath.startsWith('/') ? urlPath : `/${urlPath}`
+  if (base === '/' || pathWithLeadingSlash.startsWith(base)) {
+    return pathWithLeadingSlash
+  }
+  if (pathWithLeadingSlash === base.slice(0, -1)) {
+    return base
+  }
+
+  return `${base}${pathWithLeadingSlash.slice(1)}`
+}
 
 // 语言映射配置
 const localeMap = {
@@ -96,7 +125,7 @@ const localeMap = {
 const getSeoHead = (locale, title, description, path = '') => {
   const seoConfig = localeMap[locale] || localeMap['zh-cn']
   const canonicalUrl = path ? `${siteUrl}${path}` : `${siteUrl}/${locale}/`
-  const ogImageUrl = `${siteUrl}${base}logo.png`
+  const ogImageUrl = siteAssetUrl('logo.png')
 
   // 从路径中提取页面相对路径（去掉语言前缀）
   const getRelativePath = (fullPath, currentLocale) => {
@@ -1266,17 +1295,26 @@ export default defineConfig({
       '/zh-cn/appendix/': 0.7
     },
     transformItems(items) {
-      return items.filter((item) => {
-        const url = item.url
-        if (
-          url.includes('/extra/') ||
-          url.includes('/examples/') ||
-          url.includes('/project/')
-        ) {
-          return false
-        }
-        return true
-      })
+      return items
+        .filter((item) => {
+          const url = item.url
+          if (
+            url.includes('/extra/') ||
+            url.includes('/examples/') ||
+            url.includes('/project/')
+          ) {
+            return false
+          }
+          return true
+        })
+        .map((item) => ({
+          ...item,
+          url: withBasePath(item.url),
+          links: item.links?.map((link) => ({
+            ...link,
+            url: withBasePath(link.url)
+          }))
+        }))
     }
   },
 

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -3,6 +3,7 @@ import DefaultTheme from 'vitepress/theme'
 import { useData, useRoute, withBase } from 'vitepress'
 import TextType from './components/TextType.vue'
 import GitHubStars from './components/GitHubStars.vue'
+import PageSlidesButton from './components/PageSlidesButton.vue'
 import { onMounted, onBeforeUnmount, ref, watch, computed } from 'vue'
 import ReadingProgress from './components/ReadingProgress.vue'
 import { Setting } from '@element-plus/icons-vue'
@@ -426,6 +427,9 @@ watch(sidebarCollapsed, (collapsed) => {
     </template>
     <template #nav-bar-content-after>
       <GitHubStars />
+      <ClientOnly>
+        <PageSlidesButton />
+      </ClientOnly>
       <ClientOnly>
         <el-popover
           placement="bottom-end"

--- a/docs/.vitepress/theme/components/PageSlidesButton.vue
+++ b/docs/.vitepress/theme/components/PageSlidesButton.vue
@@ -1,0 +1,515 @@
+<script setup>
+import 'reveal.js/reveal.css'
+
+import { Close, Present } from '@element-plus/icons-vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useData, useRoute } from 'vitepress'
+
+const { frontmatter } = useData()
+const route = useRoute()
+
+const overlayRef = ref(null)
+const revealRef = ref(null)
+const slidesRef = ref(null)
+const hasDocContent = ref(false)
+const isOpen = ref(false)
+const slideCount = ref(0)
+
+let deck = null
+let previousBodyOverflow = ''
+let openedFullscreen = false
+let slideRun = 0
+
+const isDocPage = computed(() => {
+  const layout = frontmatter.value.layout
+  return layout !== 'home' && route.path !== '/welcome/' && !route.path.endsWith('/welcome/')
+})
+
+const getDocContent = () => {
+  const doc = document.querySelector('.VPDoc .vp-doc')
+  if (!doc) return null
+
+  const onlyChild = doc.children.length === 1 ? doc.firstElementChild : null
+  if (onlyChild?.querySelector?.('h1, h2, h3')) return onlyChild
+
+  return doc
+}
+
+const refreshAvailability = async () => {
+  await nextTick()
+  hasDocContent.value = Boolean(isDocPage.value && getDocContent()?.querySelector('h1, h2, h3'))
+}
+
+const isHeading = (node, level) => node.tagName?.toLowerCase() === `h${level}`
+
+const createSlideSection = (nodes, idMap, slideIndex) => {
+  const section = document.createElement('section')
+  section.className = 'ev-slide-section'
+
+  const page = document.createElement('article')
+  page.className = 'ev-slide-page vp-doc'
+  page.dataset.slideIndex = String(slideIndex)
+
+  const prefix = `ev-slide-${slideRun}-${slideIndex}-`
+  nodes.forEach((node) => {
+    const clone = node.cloneNode(true)
+    rewriteIds(clone, prefix, idMap)
+    page.appendChild(clone)
+  })
+
+  section.appendChild(page)
+  return section
+}
+
+const rewriteIds = (root, prefix, idMap) => {
+  const nodes = root.id ? [root, ...root.querySelectorAll('[id]')] : [...root.querySelectorAll('[id]')]
+
+  nodes.forEach((node) => {
+    const oldId = node.id
+    const newId = `${prefix}${oldId}`
+    idMap.set(oldId, newId)
+    node.id = newId
+  })
+}
+
+const rewriteInternalLinks = (root, idMap) => {
+  root.querySelectorAll('a[href^="#"]').forEach((link) => {
+    const oldTarget = link.getAttribute('href')?.slice(1)
+    if (!oldTarget || !idMap.has(oldTarget)) return
+    link.setAttribute('href', `#${idMap.get(oldTarget)}`)
+  })
+}
+
+const groupPageNodes = (source) => {
+  const cover = []
+  const sections = []
+  let currentH2 = null
+  let currentH3 = null
+
+  Array.from(source.children).forEach((node) => {
+    if (isHeading(node, 2)) {
+      currentH2 = {
+        intro: [node],
+        children: []
+      }
+      currentH3 = null
+      sections.push(currentH2)
+      return
+    }
+
+    if (isHeading(node, 3) && currentH2) {
+      currentH3 = {
+        nodes: [node]
+      }
+      currentH2.children.push(currentH3)
+      return
+    }
+
+    if (!currentH2) {
+      cover.push(node)
+      return
+    }
+
+    if (currentH3) {
+      currentH3.nodes.push(node)
+      return
+    }
+
+    currentH2.intro.push(node)
+  })
+
+  return { cover, sections }
+}
+
+const buildSlides = (source, slidesRoot) => {
+  const idMap = new Map()
+  const { cover, sections } = groupPageNodes(source)
+  let slideIndex = 0
+
+  slidesRoot.innerHTML = ''
+  slideRun += 1
+
+  if (cover.length) {
+    slideIndex += 1
+    slidesRoot.appendChild(createSlideSection(cover, idMap, slideIndex))
+  }
+
+  if (!sections.length && !cover.length) {
+    slideIndex += 1
+    slidesRoot.appendChild(createSlideSection(Array.from(source.children), idMap, slideIndex))
+  }
+
+  sections.forEach((section) => {
+    if (!section.children.length) {
+      slideIndex += 1
+      slidesRoot.appendChild(createSlideSection(section.intro, idMap, slideIndex))
+      return
+    }
+
+    const horizontal = document.createElement('section')
+    horizontal.className = 'ev-slide-stack'
+
+    slideIndex += 1
+    horizontal.appendChild(createSlideSection(section.intro, idMap, slideIndex))
+
+    section.children.forEach((child) => {
+      slideIndex += 1
+      horizontal.appendChild(createSlideSection(child.nodes, idMap, slideIndex))
+    })
+
+    slidesRoot.appendChild(horizontal)
+  })
+
+  rewriteInternalLinks(slidesRoot, idMap)
+  return slideIndex
+}
+
+const requestOverlayFullscreen = async () => {
+  const overlay = overlayRef.value
+  if (!overlay?.requestFullscreen || document.fullscreenElement) return
+
+  try {
+    await overlay.requestFullscreen()
+    openedFullscreen = true
+  } catch {
+    openedFullscreen = false
+  }
+}
+
+const getRevealSize = () => {
+  if (window.innerWidth <= 768) {
+    return {
+      width: window.innerWidth,
+      height: window.innerHeight,
+      margin: 0.02
+    }
+  }
+
+  return {
+    width: 1280,
+    height: 720,
+    margin: 0.04
+  }
+}
+
+const openSlides = async () => {
+  const source = getDocContent()
+  if (!source || isOpen.value) return
+
+  isOpen.value = true
+  previousBodyOverflow = document.body.style.overflow
+  document.body.style.overflow = 'hidden'
+
+  await nextTick()
+
+  if (!slidesRef.value || !revealRef.value) {
+    await closeSlides()
+    return
+  }
+
+  slideCount.value = buildSlides(source, slidesRef.value)
+
+  const { default: Reveal } = await import('reveal.js')
+  const size = getRevealSize()
+  deck = new Reveal(revealRef.value, {
+    controls: true,
+    progress: true,
+    hash: false,
+    history: false,
+    center: false,
+    width: size.width,
+    height: size.height,
+    margin: size.margin,
+    minScale: 0.2,
+    maxScale: 2,
+    transition: 'slide'
+  })
+
+  await deck.initialize()
+  void requestOverlayFullscreen().then(() => deck?.layout?.())
+  overlayRef.value?.focus()
+}
+
+const closeSlides = async () => {
+  if (!isOpen.value) return
+
+  if (deck) {
+    deck.destroy()
+    deck = null
+  }
+
+  if (openedFullscreen && document.fullscreenElement) {
+    try {
+      await document.exitFullscreen()
+    } catch {
+      // Keep closing the overlay even if the browser rejects fullscreen exit.
+    }
+  }
+
+  openedFullscreen = false
+  isOpen.value = false
+  slideCount.value = 0
+  document.body.style.overflow = previousBodyOverflow
+
+  await nextTick()
+  if (slidesRef.value) slidesRef.value.innerHTML = ''
+}
+
+watch(
+  () => route.path,
+  async () => {
+    await closeSlides()
+    await refreshAvailability()
+  }
+)
+
+watch(isDocPage, refreshAvailability)
+
+onMounted(refreshAvailability)
+
+onBeforeUnmount(() => {
+  if (deck) deck.destroy()
+  document.body.style.overflow = previousBodyOverflow
+})
+</script>
+
+<template>
+  <button
+    v-if="hasDocContent"
+    class="ev-slides-button"
+    type="button"
+    aria-label="打开幻灯片"
+    title="幻灯片"
+    @click="openSlides"
+  >
+    <el-icon :size="16">
+      <Present />
+    </el-icon>
+    <span class="ev-slides-button-label">幻灯片</span>
+  </button>
+
+  <Teleport to="body">
+    <div
+      v-if="isOpen"
+      ref="overlayRef"
+      class="ev-slides-overlay"
+      tabindex="-1"
+      role="dialog"
+      aria-modal="true"
+      aria-label="页面幻灯片播放"
+      @keydown.esc.stop.prevent="closeSlides"
+    >
+      <button
+        class="ev-slides-close"
+        type="button"
+        aria-label="关闭幻灯片"
+        title="关闭幻灯片"
+        @click="closeSlides"
+      >
+        <el-icon :size="18">
+          <Close />
+        </el-icon>
+      </button>
+
+      <div class="ev-slides-shell">
+        <div
+          ref="revealRef"
+          class="reveal ev-page-slides"
+          :data-slide-count="slideCount"
+        >
+          <div ref="slidesRef" class="slides" />
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style>
+.ev-slides-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  height: 32px;
+  min-width: 32px;
+  margin-left: 12px;
+  padding: 0 12px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.ev-slides-button:hover {
+  border-color: var(--vp-c-brand);
+  color: var(--vp-c-brand);
+}
+
+.ev-slides-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  color: #1f2937;
+  background: #f8fafc;
+  outline: none;
+}
+
+.ev-slides-shell {
+  width: 100%;
+  height: 100%;
+}
+
+.ev-slides-close {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 10010;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 1px solid rgba(148, 163, 184, 0.42);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #334155;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.14);
+  cursor: pointer;
+}
+
+.ev-slides-close:hover {
+  border-color: #2563eb;
+  color: #2563eb;
+}
+
+.ev-page-slides {
+  width: 100%;
+  height: 100%;
+  background: #f8fafc;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+.ev-page-slides .slides {
+  text-align: left;
+}
+
+.ev-page-slides section {
+  height: 100%;
+}
+
+.ev-page-slides .ev-slide-section {
+  padding: 0;
+  background: transparent;
+}
+
+.ev-page-slides .ev-slide-page {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  max-height: 100%;
+  padding: 48px 58px;
+  overflow: auto;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 18px;
+  background: #ffffff;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.14);
+  color: var(--vp-c-text-1);
+  font-size: 22px;
+  line-height: 1.62;
+}
+
+.ev-page-slides .ev-slide-page > :first-child {
+  margin-top: 0;
+}
+
+.ev-page-slides .ev-slide-page > :last-child {
+  margin-bottom: 0;
+}
+
+.ev-page-slides .ev-slide-page h1 {
+  margin-bottom: 24px;
+  font-size: 48px;
+  line-height: 1.16;
+}
+
+.ev-page-slides .ev-slide-page h2 {
+  margin-bottom: 22px;
+  font-size: 38px;
+  line-height: 1.2;
+}
+
+.ev-page-slides .ev-slide-page h3 {
+  margin-bottom: 20px;
+  font-size: 32px;
+  line-height: 1.25;
+}
+
+.ev-page-slides .ev-slide-page h4 {
+  font-size: 26px;
+}
+
+.ev-page-slides .ev-slide-page p,
+.ev-page-slides .ev-slide-page li,
+.ev-page-slides .ev-slide-page blockquote,
+.ev-page-slides .ev-slide-page td,
+.ev-page-slides .ev-slide-page th {
+  font-size: inherit;
+}
+
+.ev-page-slides .ev-slide-page img,
+.ev-page-slides .ev-slide-page video,
+.ev-page-slides .ev-slide-page canvas,
+.ev-page-slides .ev-slide-page svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.ev-page-slides .ev-slide-page table {
+  display: table;
+  width: 100%;
+}
+
+.ev-page-slides .controls {
+  color: #2563eb;
+}
+
+.ev-page-slides .progress {
+  color: #2563eb;
+}
+
+@media (max-width: 768px) {
+  .ev-slides-button {
+    width: 32px;
+    margin-left: 8px;
+    padding: 0;
+  }
+
+  .ev-slides-button-label {
+    display: none;
+  }
+
+  .ev-page-slides .ev-slide-page {
+    padding: 34px 28px;
+    border-radius: 14px;
+    font-size: 18px;
+  }
+
+  .ev-page-slides .ev-slide-page h1 {
+    font-size: 34px;
+  }
+
+  .ev-page-slides .ev-slide-page h2 {
+    font-size: 28px;
+  }
+
+  .ev-page-slides .ev-slide-page h3 {
+    font-size: 24px;
+  }
+}
+</style>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -45,7 +45,12 @@ SITE_URL="https://<owner>.github.io/<repo-name>"
 
 3. 如果改动影响页面渲染或交互，启动本地预览并用官方 Codex in-app browser 验证相关页面。
 4. 提交目标变更并推送到 fork `main`。
-5. 等待 `Deploy VitePress site to Pages` workflow 完成。
+5. 等待 `Deploy VitePress site to Pages` workflow 完成。如果 push 后 60 秒内没有出现 run，用下面的 fallback 触发同一个 workflow：
+
+   ```bash
+   gh workflow run deploy.yml --repo longbiaochen/easy-vibe --ref main
+   ```
+
 6. 在官方 Codex in-app browser 打开 fork Pages：
 
    ```text

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,119 +1,104 @@
-# 🚀 部署说明
+# 部署说明
 
-## Base 路径自动适配
+本项目是 VitePress 文档站，生产输出目录是 `docs/.vitepress/dist`。GitHub Pages 使用 `.github/workflows/deploy.yml` 自编译部署，不提交构建产物。
 
-本项目的 VitePress 配置已经正确处理了 **Vercel** 和 **GitHub Pages** 两种部署环境的不同 base 路径。
+## 部署目标
 
-### 自动适配逻辑
+| 目标                 | URL                                           | 触发方式                  |
+| -------------------- | --------------------------------------------- | ------------------------- |
+| 上游 GitHub Pages    | `https://datawhalechina.github.io/easy-vibe/` | 上游 `main` push 自动部署 |
+| 当前 fork Pages      | `https://longbiaochen.github.io/easy-vibe/`   | fork `main` push 自动部署 |
+| Vercel               | 由 Vercel 项目域名决定                        | Vercel 自动构建           |
+| 本地预览             | `http://localhost:4173/easy-vibe/`            | `npm run preview`         |
 
-```javascript
-// docs/.vitepress/config.mjs
-const isVercel = process.env.VERCEL === '1'
-const base = isVercel ? '/' : '/easy-vibe/'
+fork 默认不会部署 Pages。需要在 fork 仓库中启用 GitHub Pages 的 GitHub Actions 发布源，并设置仓库变量 `ENABLE_PAGES_DEPLOY=true`。
+
+## Base 和站点 URL
+
+`docs/.vitepress/config.mjs` 支持通过环境变量覆盖部署路径：
+
+- `BASE` 控制 VitePress 静态资源和路由前缀。
+- `SITE_URL` 控制 canonical、Open Graph、sitemap 和 robots 中的站点 URL。
+
+GitHub Actions 会默认设置：
+
+```bash
+BASE="/<repo-name>/"
+SITE_URL="https://<owner>.github.io/<repo-name>"
 ```
 
-### 部署环境对比
+如果需要自定义域名或非标准路径，在仓库变量中设置：
 
-| 平台             | Base 路径     | 示例 URL                                                    |
-| ---------------- | ------------- | ----------------------------------------------------------- |
-| **Vercel**       | `/`           | `https://your-project.vercel.app/cn/stage-1/...`            |
-| **GitHub Pages** | `/easy-vibe/` | `https://datawhalechina.github.io/easy-vibe/cn/stage-1/...` |
-| **本地开发**     | `/easy-vibe/` | `http://localhost:5173/easy-vibe/cn/stage-1/...`            |
-| **本地预览**     | `/easy-vibe/` | `http://localhost:4173/easy-vibe/cn/stage-1/...`            |
+- `PAGES_BASE`
+- `PAGES_SITE_URL`
 
-### 首页动态链接
+## Ship-It 流程
 
-首页使用 VitePress 的 `useData()` API 来动态获取 base 路径：
+当操作者说 `ship it` 时，按下面顺序执行：
 
-```vue
-<script setup>
-import { useData } from 'vitepress'
-
-const { site } = useData()
-const base = site.value.base
-</script>
-
-<template>
-  <a :href="base + 'cn/stage-1/learning-map/'">
-    <!-- 链接会自动适配部署环境 -->
-  </a>
-</template>
-```
-
-**优点**：
-
-- ✅ 无需硬编码 fallback 值
-- ✅ 自动适配 Vercel 和 GitHub Pages
-- ✅ 构建时和运行时都正确
-
-## 部署步骤
-
-### Vercel 部署
-
-1. 推送代码到 GitHub
-2. Vercel 会自动检测 `vercel.json` 配置
-3. 自动构建并部署
-4. 访问 `https://your-project.vercel.app`
-
-**环境变量**：Vercel 自动设置 `VERCEL=1`
-
-### GitHub Pages 部署
-
-1. 配置 GitHub Pages 设置：
-   - Source: `gh-pages` 分支
-   - 或使用 GitHub Actions 从 `main` 分支部署
-
-2. 构建命令：
+1. 确认只发布本次目标变更，保留无关 dirty 文件。
+2. 运行本地验证：
 
    ```bash
-   npm run build
+   npm run verify
    ```
 
-3. 访问 `https://datawhalechina.github.io/easy-vibe`
+3. 如果改动影响页面渲染或交互，启动本地预览并用官方 Codex in-app browser 验证相关页面。
+4. 提交目标变更并推送到 fork `main`。
+5. 等待 `Deploy VitePress site to Pages` workflow 完成。
+6. 在官方 Codex in-app browser 打开 fork Pages：
 
-## 验证部署
+   ```text
+   https://longbiaochen.github.io/easy-vibe/
+   ```
 
-部署后检查以下链接是否正常：
+7. 验证首页、`/welcome.html`、相关变更页面、导航、资源加载和 canonical/sitemap/robots URL。
+8. 预览确认后，整理相对 `upstream/main` 的变更摘要，并询问操作者是否创建上游 PR。没有明确确认前，不创建 PR。
 
-- [ ] 首页能正常访问
-- [ ] 导航栏链接能正确跳转
-- [ ] 首页卡片"查看详情"链接正确
-- [ ] 语言切换功能正常
-- [ ] 图片资源能正常加载
+## 一次性 fork 配置
+
+首次启用 fork Pages 时执行：
+
+```bash
+git remote add upstream git@github.com:datawhalechina/easy-vibe.git
+gh variable set ENABLE_PAGES_DEPLOY --repo longbiaochen/easy-vibe --body true
+gh api repos/longbiaochen/easy-vibe/pages -X POST -f build_type=workflow
+gh repo edit longbiaochen/easy-vibe --homepage https://longbiaochen.github.io/easy-vibe/
+```
+
+如果 `upstream` 已存在，用下面命令确认它指向上游：
+
+```bash
+git remote set-url upstream git@github.com:datawhalechina/easy-vibe.git
+```
+
+## 验证清单
+
+- [ ] `npm run verify` 通过。
+- [ ] GitHub Actions Pages workflow 成功部署。
+- [ ] fork Pages 首页能正常访问。
+- [ ] `/welcome.html` 能正常访问。
+- [ ] 本次变更涉及的页面能正常访问。
+- [ ] 导航、语言切换和图片资源能正常加载。
+- [ ] canonical、sitemap 和 robots 指向当前部署域名。
+- [ ] 只有在操作者明确确认后，才创建到上游的 PR。
 
 ## 常见问题
 
-### Q: Vercel 部署后链接变成 `/easy-vibe/cn/...` 导致 404
+### fork push 后没有部署
 
-**原因**：Vercel 环境变量未正确设置
-
-**解决**：
-
-1. 检查 Vercel 项目设置中 `Environment Variables`
-2. 确保 `VERCEL` = `1` 已设置（通常自动设置）
-3. 重新部署
-
-### Q: GitHub Pages 部署后所有链接 404
-
-**原因**：缺少 `/easy-vibe/` base 路径
-
-**解决**：
-
-1. 检查 `docs/.vitepress/config.mjs` 中的 base 配置
-2. 确保 GitHub Pages 环境下 `isVercel = false`
-3. 重新构建并部署
-
-### Q: 本地预览链接缺少 `/easy-vibe/` 前缀
-
-**原因**：使用了错误的预览命令
-
-**解决**：
+检查 fork 仓库变量：
 
 ```bash
-# 错误
-npm run preview  # 默认端口 4173，但路径可能不对
-
-# 正确
-npm run build
-npm run preview  # 访问 http://localhost:4173/easy-vibe/
+gh variable list --repo longbiaochen/easy-vibe
 ```
+
+必须有 `ENABLE_PAGES_DEPLOY=true`。如果 Pages 仍未启用，确认 GitHub Pages source 是 GitHub Actions。
+
+### 页面资源 404
+
+通常是 `BASE` 不正确。GitHub Pages 项目站点应使用 `/<repo-name>/`，当前 fork 是 `/easy-vibe/`。
+
+### sitemap 或 robots 指向上游
+
+通常是 `SITE_URL` 没有设置。GitHub Actions 默认会按当前仓库所有者生成 fork URL；自定义域名时设置 `PAGES_SITE_URL`。

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "claude": "^0.1.1",
         "element-plus": "^2.13.1",
         "mermaid": "^11.13.0",
+        "reveal.js": "^6.0.1",
         "typeit": "^8.8.7",
         "viewerjs": "^1.11.7",
         "vitepress": "^2.0.0-alpha.16",
@@ -4202,6 +4203,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/reveal.js": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-6.0.1.tgz",
+      "integrity": "sha512-9eacArNIgqO2HGWOK+93gJNn+gvdGDVbSq+i2u3Ja9kjiHps0XNLpgYTZTYjKRH91uXy3clGimeGiw4umHG/tg==",
+      "license": "MIT"
     },
     "node_modules/rfdc": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "claude": "^0.1.1",
     "element-plus": "^2.13.1",
     "mermaid": "^11.13.0",
+    "reveal.js": "^6.0.1",
     "typeit": "^8.8.7",
     "viewerjs": "^1.11.7",
     "vitepress": "^2.0.0-alpha.16",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vitepress dev docs",
-    "build": "npm run sitemap && vitepress build docs",
-    "build:force": "npm run sitemap && vitepress build docs --force",
+    "build": "npm run sitemap && node scripts/build.mjs",
+    "build:force": "npm run sitemap && node scripts/build.mjs --force",
     "preview": "vitepress preview docs",
     "format": "prettier --write .",
     "verify": "bash scripts/verify.sh",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -7,10 +7,21 @@
  * 同时保留真实的退出码供 CI 使用。
  */
 import { spawn } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const child = spawn('npx', ['vitepress', 'build', 'docs', '--force'], {
-  stdio: 'inherit',
-  shell: true
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, '..')
+const vitepressBin = path.join(
+  rootDir,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'vitepress.cmd' : 'vitepress'
+)
+const vitepressArgs = ['build', 'docs', ...process.argv.slice(2)]
+
+const child = spawn(vitepressBin, vitepressArgs, {
+  stdio: 'inherit'
 })
 
 child.on('close', (code) => {

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -171,7 +171,7 @@ function main() {
     baseFiles = scanMarkdownFiles(docsDir).filter((f) => !f.includes('/'))
   }
 
-  console.log(`📄 Found ${baseFiles} base pages`)
+  console.log(`📄 Found ${baseFiles.length} base pages`)
 
   // 为每个文件生成 URL 信息
   for (const baseFile of baseFiles) {

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> Linting VitePress theme"
+npm run lint
+
+echo
+echo "==> Building without rewriting the tracked sitemap"
+SITEMAP_NO_WRITE=1 npm run build


### PR DESCRIPTION
## Summary

- Enable fork opt-in GitHub Pages deployment with dynamic `BASE` / `SITE_URL` defaults and repo-variable overrides.
- Add a repeatable `ship it` runbook, verification script, and deployment docs for fork preview before upstream PRs.
- Fix generated Pages sitemap and social image URLs so fork builds keep the `/easy-vibe/` base path.
- Include the browser slide controls already shipped on this fork branch for docs page presentation.

## Preview

Fork Pages preview: https://longbiaochen.github.io/easy-vibe/

Latest fork deployment run: https://github.com/longbiaochen/easy-vibe/actions/runs/25371100370

## Validation

- `BASE=/easy-vibe/ SITE_URL=https://longbiaochen.github.io/easy-vibe npm run verify`
- Pre-push forced build passed when pushing `main` and `codex/fork-pages-ship-flow`.
- GitHub Pages workflow run `25371100370` completed successfully for commit `82833eb`.
- Live checks confirmed `/easy-vibe/`, `/easy-vibe/welcome.html`, `/easy-vibe/DEPLOYMENT.html`, and `/easy-vibe/zh-cn/appendix/3-browser-and-frontend/html-css-layout.html` return 200.
- Live `robots.txt` points to `https://longbiaochen.github.io/easy-vibe/sitemap.xml`, and the live sitemap no longer emits URLs missing `/easy-vibe/`.
- In-app browser verification loaded the fork preview, exercised the welcome entry flow into `/easy-vibe/en/`, and confirmed page assets use the `/easy-vibe/` base path.
