### PR TITLE
docs: mention MiniMax-M3 alongside M2.7 in integration guide

### DIFF
--- a/docs/en/stage-1/integrating-ai-capabilities/index.md
+++ b/docs/en/stage-1/integrating-ai-capabilities/index.md
@@ -173,15 +173,16 @@ In addition to DeepSeek, you can also try other large language models. Since mos
 
 ::: details Learn More: What is MiniMax?
 
-**MiniMax** is a Chinese AI company dedicated to general artificial intelligence research. MiniMax has developed its own MiniMax-M2.7 series of large language models, which perform well in multiple benchmarks with excellent cost-effectiveness.
+**MiniMax** is a Chinese AI company dedicated to general artificial intelligence research. MiniMax has released the MiniMax-M3 and MiniMax-M2.7 series of large language models, which perform well in multiple benchmarks with excellent cost-effectiveness.
 
-**Key Features of MiniMax-M2.7 Series:**
+**Key Features of the MiniMax Series:**
 
-- **Ultra-long context**: Supports a 204,800-token context window, suitable for processing long documents and multi-turn conversations
+- **Ultra-long context**: M3 supports up to a 512K-token context window (M2.7 supports 204,800 tokens), suitable for processing long documents and multi-turn conversations
 - **Cost-effective**: Extremely competitive pricing
 - **OpenAI-compatible API**: Can be called directly using the OpenAI SDK, no need to learn a new API format
-- **Two available models**:
-  - `MiniMax-M2.7`: Flagship model for complex tasks
+- **Available models**:
+  - `MiniMax-M3`: Latest flagship model with 512K context, 128K max output, and image input support
+  - `MiniMax-M2.7`: Previous flagship model, still available
   - `MiniMax-M2.7-highspeed`: High-speed version with same performance but faster response
 :::
 
@@ -198,7 +199,7 @@ curl https://api.minimax.io/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${MINIMAX_API_KEY}" \
   -d '{
-        "model": "MiniMax-M2.7",
+        "model": "MiniMax-M3",
         "messages": [
           {"role": "system", "content": "You are a helpful assistant."},
           {"role": "user", "content": "Hello!"}
@@ -211,7 +212,7 @@ curl https://api.minimax.io/v1/chat/completions \
 MiniMax's API format is almost identical to DeepSeek (both are OpenAI-compatible), so if you've already successfully integrated DeepSeek, switching to MiniMax only requires changing three things:
 1. **Base URL**: Change to `https://api.minimax.io/v1`
 2. **API Key**: Use your MiniMax API Key
-3. **Model name**: Change to `MiniMax-M2.7` or `MiniMax-M2.7-highspeed`
+3. **Model name**: Change to `MiniMax-M3` (new flagship), `MiniMax-M2.7`, or `MiniMax-M2.7-highspeed`
 
 For more details, refer to the [MiniMax OpenAI Compatible API Documentation](https://platform.minimax.io/docs/api-reference/text-openai-api).
 :::

--- a/docs/zh-cn/stage-1/integrating-ai-capabilities/index.md
+++ b/docs/zh-cn/stage-1/integrating-ai-capabilities/index.md
@@ -173,15 +173,16 @@ curl  \
 
 ::: details 了解更多：MiniMax 是什么？
 
-**MiniMax** 是一家中国人工智能公司，致力于通用人工智能技术的研发。MiniMax 推出了自研的 MiniMax-M2.7 大语言模型系列，在多项基准测试中表现优异，具有极高的性价比。
+**MiniMax** 是一家中国人工智能公司，致力于通用人工智能技术的研发。MiniMax 已陆续推出 MiniMax-M3 与 MiniMax-M2.7 大语言模型系列，在多项基准测试中表现优异，具有极高的性价比。
 
-**MiniMax-M2.7 系列的主要特点：**
+**MiniMax 系列的主要特点：**
 
-- **超长上下文**：支持 204,800 tokens 的上下文窗口，适合处理长文档、多轮对话
+- **超长上下文**：M3 支持高达 512K tokens 的上下文窗口（M2.7 为 204,800 tokens），适合处理长文档、多轮对话
 - **高性价比**：价格极具竞争力
 - **OpenAI 兼容接口**：可以直接使用 OpenAI SDK 调用，无需额外学习新的 API 格式
-- **两个可用模型**：
-  - `MiniMax-M2.7`：旗舰模型，适合复杂任务
+- **可用模型**：
+  - `MiniMax-M3`：最新旗舰模型，512K 上下文、128K 最大输出，并支持图像输入
+  - `MiniMax-M2.7`：上一代旗舰模型，仍然可用
   - `MiniMax-M2.7-highspeed`：高速版本，保持同样的性能但更快
 :::
 
@@ -198,7 +199,7 @@ curl https://api.minimax.io/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${MINIMAX_API_KEY}" \
   -d '{
-        "model": "MiniMax-M2.7",
+        "model": "MiniMax-M3",
         "messages": [
           {"role": "system", "content": "You are a helpful assistant."},
           {"role": "user", "content": "Hello!"}
@@ -211,7 +212,7 @@ curl https://api.minimax.io/v1/chat/completions \
 MiniMax 的 API 格式与 DeepSeek 几乎完全一致（都是 OpenAI 兼容格式），所以如果你已经成功接入了 DeepSeek，切换到 MiniMax 只需要修改三个地方：
 1. **基础 URL**：改为 `https://api.minimax.io/v1`
 2. **API Key**：使用 MiniMax 的 API Key
-3. **模型名称**：改为 `MiniMax-M2.7` 或 `MiniMax-M2.7-highspeed`
+3. **模型名称**：改为 `MiniMax-M3`（新旗舰）、`MiniMax-M2.7` 或 `MiniMax-M2.7-highspeed`
 
 更多信息请参考 [MiniMax OpenAI 兼容接口文档](https://platform.minimax.io/docs/api-reference/text-openai-api)。
 :::


### PR DESCRIPTION
## Summary

Add the newer MiniMax-M3 flagship to the model option list in the stage-1 "Integrating AI Capabilities" tutorial, while keeping MiniMax-M2.7 and -M2.7-highspeed as documented alternatives. Mirrors the same edits in zh-cn (primary) and en (secondary) per the translation priority outlined in AGENTS.md.

## Changes

- Update the "What is MiniMax" details panel to introduce M3 (512K context window, 128K max output, image input support) alongside the existing M2.7 series description.
- Update the curl example default model from `MiniMax-M2.7` to `MiniMax-M3`.
- Update the "Three things to change" tip to suggest `MiniMax-M3` (new flagship) first.
- Affected files: `docs/zh-cn/stage-1/integrating-ai-capabilities/index.md`, `docs/en/stage-1/integrating-ai-capabilities/index.md`.

Other locales (zh-tw / ja-jp / ko-kr / es-es / fr-fr / de-de / ar-sa / vi-vn) are intentionally left for follow-up translation per the project's translation-priority guideline (zh-cn primary, en-us secondary, others tertiary), to keep this PR small and easy to review.

## Why

MiniMax-M3 is the new flagship model with 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Mentioning it alongside M2.7 lets new readers know about the latest model from day one without removing the M2.7 variants that are still useful for cost/speed-sensitive scenarios.

## Testing

- `npm run build:force` was run locally; sitemap generation and the vitepress build started without error before being interrupted by the test environment.
- Diff is text-only inside `.md` files; no Vue components or scripts changed, so ESLint and component checks are unaffected.
- Pre-commit hook ran and skipped successfully (no Vue files in commit).