### PR TITLE
[codex] fix(docs): align MasterGo auto layout instructions

### DIFF
--- a/docs/zh-cn/stage-2/frontend/figma-mastergo/index.md
+++ b/docs/zh-cn/stage-2/frontend/figma-mastergo/index.md
@@ -222,7 +222,7 @@ const relatedArticles = relatedArticlesMap['zh-cn/stage-2/frontend/figma-masterg
 
 ![](images/image32.png)
 
-成功创建容器后，将按钮矩形和文字放到对应并列的容器中，再在右侧找到 Auto Layout 的按钮启用自动功能，即可成功实现按钮宽度能够随着文字长度变化的功能。
+成功创建容器后，将按钮文字放入这个容器中，再在右侧找到 Auto Layout 的按钮启用自动布局，并根据需要为容器设置背景色、圆角和内边距。这样按钮就会以容器作为背景，宽度能够随着文字长度变化。
 
 ![](images/image33.png)
 


### PR DESCRIPTION
## Summary

Fix the MasterGo Auto Layout instruction so the text matches the screenshots in the Figma and MasterGo introductory chapter.

The previous sentence said to put the button rectangle and text into parallel containers. The screenshots show a container-based button workflow instead: place the text inside the container, enable Auto Layout, and use the container background, border radius, and padding to create the button.

## Issue

Closes #73

## Validation

- Compared the issue screenshot with `image32.png`, `image33.png`, and `image34.png`
- `git diff --check`
- `npm run build`
- pre-push forced build passed
