### PR TITLE
fix(vi-vn): add Vietnamese diacritical marks to stage-1 files

### DIFF
--- a/docs/vi-vn/stage-1/ai-capabilities-through-games/index.md
+++ b/docs/vi-vn/stage-1/ai-capabilities-through-games/index.md
@@ -1,183 +1,183 @@
-# So cap 1: Thoi dai AI, biet noi la biet lap trinh
+# Sơ cấp 1: Thời đại AI, biết nói là biết lập trình
 
-Day la mot bai hoc **hoc theo du an**. Ban hay lam theo tung buoc va co gang tai hien ket qua.
-Dung lo sai hay sua. Hay nho:
+Đây là một bài học **học theo dự án**. Bạn hãy làm theo từng bước và cố gắng tái hiện kết quả.
+Đừng lo sai hay sửa. Hãy nhớ:
 
 <div style="text-align: center;">
 <div style="display: inline-block; padding: 8px 20px; border-radius: 8px; border: 1px dashed #FFB6C1; background: linear-gradient(135deg, #FFF0F5 0%, #FFE4EC 100%); margin: 12px 0;">
-  <span style="font-size: 15px; font-weight: 500; color: #666;">Hoan thanh quan trong hon hoan hao</span>
+  <span style="font-size: 15px; font-weight: 500; color: #666;">Hoàn thành quan trọng hơn hoàn hảo</span>
 </div>
 </div>
 
 <script setup>
 import { relatedArticlesMap } from '@theme/data/relatedArticles'
 
-const duration = 'khoang <strong>4 gio</strong> (co the chia nhieu lan)'
+const duration = 'khoảng <strong>4 giờ</strong> (có thể chia nhiều lần)'
 const relatedArticles =
   relatedArticlesMap['vi-vn/stage-1/ai-capabilities-through-games'] ?? []
 </script>
 
-## Dan nhap chuong
+## Dẫn nhập chương
 
-<ChapterIntroduction :duration="duration" :tags="['Lap trinh doi thoai', 'Mini game AI-native', 'Thuc hanh Snake']" coreOutput="Snake AI-native + mini game tu tao" expectedOutput="1 Snake AI-native chay duoc + (tuy chon) 1 mini game/demo tu tao">
+<ChapterIntroduction :duration="duration" :tags="['Lập trình đối thoại', 'Mini game AI-native', 'Thực hành Snake']" coreOutput="Snake AI-native + mini game tự tạo" expectedOutput="1 Snake AI-native chạy được + (tùy chọn) 1 mini game/demo tự tạo">
 
-Neu ban <strong>hoan toan khong biet lap trinh</strong> hoac chi biet mot chut, chuong nay danh cho ban. Ta se bat dau tu co ban: dung <strong>doi thoai</strong> de AI giup ban viet code. Khong can nho cu phap, khong can cau hinh phuc tap, nhieu truong hop co the chay ngay tren web.
+Nếu bạn <strong>hoàn toàn không biết lập trình</strong> hoặc chỉ biết một chút, chương này dành cho bạn. Ta sẽ bắt đầu từ cơ bản: dùng <strong>đối thoại</strong> để AI giúp bạn viết code. Không cần nhớ cú pháp, không cần cấu hình phức tạp, nhiều trường hợp có thể chạy ngay trên web.
 
-Ban se tu tay lam ra <strong>chuong trinh dau tien chay duoc</strong>: mot phien ban Snake co the "an tu", "viet tho", "ve ve". Ban se cam nhan lap trinh voi AI la gi: khong phai AI nghi thay ban, ma ban noi ro y muon, AI giup ban hien thuc.
+Bạn sẽ tự tay làm ra <strong>chương trình đầu tiên chạy được</strong>: một phiên bản Snake có thể "ăn từ", "viết thơ", "vẽ vẽ". Bạn sẽ cảm nhận lập trình với AI là gì: không phải AI nghĩ thay bạn, mà bạn nói rõ ý muốn, AI giúp bạn hiện thực.
 
 </ChapterIntroduction>
 
 <div style="margin: 50px 0;">
   <ClientOnly>
     <StepBar :active="0" :items="[
-      { title: 'Khoi dong', description: 'Thoi dai AI: biet noi la biet lap trinh' },
-      { title: 'Kham pha nhanh', description: 'Trai nghiem 60 giay' },
-      { title: 'Thuc hanh AI-native', description: 'Xay Snake AI-native' },
-      { title: 'Mo rong sang tao', description: 'Tu lam mot game khac' }
+      { title: 'Khởi động', description: 'Thời đại AI: biết nói là biết lập trình' },
+      { title: 'Khám phá nhanh', description: 'Trải nghiệm 60 giây' },
+      { title: 'Thực hành AI-native', description: 'Xây Snake AI-native' },
+      { title: 'Mở rộng sáng tạo', description: 'Tự làm một game khác' }
     ]" />
   </ClientOnly>
 </div>
 
-## 1. Kho khan cua nguoi binh thuong va co hoi moi
+## 1. Khó khăn của người bình thường và cơ hội mới
 
-Rat nhieu nguoi co y tuong san pham: cong cu ghi chep chi tieu, mot trang web ghi lai qua trinh lon len cua con, hoac mot mini game. Nhung chi can nghi toi "viet code" va "tim lap trinh vien" la thay met.
+Rất nhiều người có ý tưởng sản phẩm: công cụ ghi chép chi tiêu, một trang web ghi lại quá trình lớn lên của con, hoặc một mini game. Nhưng chỉ cần nghĩ tới "viết code" và "tìm lập trình viên" là thấy mệt.
 
-AI tao ra mot kha nang moi: ban khong nhat thiet phai biet code ngay lap tuc; ban can hoc cach noi ro rang voi AI ve dieu ban muon. Ke ca voi lap trinh vien chuyen nghiep, AI dang dan tro thanh mot phan cua quy trinh lam viec. Voi nguoi moi, kha nang "giao tiep dung voi agent" la cuc ky co gia tri.
+AI tạo ra một khả năng mới: bạn không nhất thiết phải biết code ngay lập tức; bạn cần học cách nói rõ ràng với AI về điều bạn muốn. Kể cả với lập trình viên chuyên nghiệp, AI đang dần trở thành một phần của quy trình làm việc. Với người mới, khả năng "giao tiếp đúng với agent" là cực kỳ có giá trị.
 
-Muc tieu cua bai hoc la giup ban hinh thanh ky nang moi: <strong>dung ngon ngu tu nhien de lam ung dung</strong>. Ban se hoc cach mo ta muc tieu, chia buoc, xac dinh dau vao/dau ra, va sua loi khi ket qua chua dung y.
+Mục tiêu của bài học là giúp bạn hình thành kỹ năng mới: <strong>dùng ngôn ngữ tự nhiên để làm ứng dụng</strong>. Bạn sẽ học cách mô tả mục tiêu, chia bước, xác định đầu vào/đầu ra, và sửa lỗi khi kết quả chưa đúng ý.
 
 <div style="margin: 50px 0;">
   <ClientOnly>
     <StepBar :active="1" :items="[
-      { title: 'Kho khan va co hoi', description: 'Mot cach moi de tao san pham' },
-      { title: 'Kham pha nhanh', description: 'Trai nghiem 60 giay' },
-      { title: 'Thuc hanh AI-native', description: 'Xay Snake AI-native' },
-      { title: 'Mo rong sang tao', description: 'Tu lam mot game khac' }
+      { title: 'Khó khăn và cơ hội', description: 'Một cách mới để tạo sản phẩm' },
+      { title: 'Khám phá nhanh', description: 'Trải nghiệm 60 giây' },
+      { title: 'Thực hành AI-native', description: 'Xây Snake AI-native' },
+      { title: 'Mở rộng sáng tạo', description: 'Tự làm một game khác' }
     ]" />
   </ClientOnly>
 </div>
 
-## 2. AI co the lam duoc toi muc nao hien nay
+## 2. AI có thể làm được tới mức nào hiện nay
 
-Cau hoi cu the: neu ban khong biet viet code, ban co the lam duoc toi muc nao voi AI doi thoai?
+Câu hỏi cụ thể: nếu bạn không biết viết code, bạn có thể làm được tới mức nào với AI đối thoại?
 
-Thuc te, hien nay AI rat hop de:
+Thực tế, hiện nay AI rất hợp để:
 
-- cong cu noi bo nho,
-- bang dieu khien/truc quan du lieu,
-- mini game nhe,
-- prototype de kiem chung y tuong tu goc nhin san pham.
+- công cụ nội bộ nhỏ,
+- bảng điều khiển/trực quan dữ liệu,
+- mini game nhẹ,
+- prototype để kiểm chứng ý tưởng từ góc nhìn sản phẩm.
 
-Voi san pham lon va dua vao san xuat, van can con nguoi dau tu vao thiet ke luong, chi tiet, bao mat, hieu nang va kha nang bao tri. Nhưng doi voi prototype va cong cu tu dung, chat luong da rat thuc dung.
+Với sản phẩm lớn và đưa vào sản xuất, vẫn cần con người đầu tư vào thiết kế luồng, chi tiết, bảo mật, hiệu năng và khả năng bảo trì. Nhưng đối với prototype và công cụ tự dùng, chất lượng đã rất thực dụng.
 
-### 2.1 Lam Snake trong 60 giay (voi z.ai)
+### 2.1 Làm Snake trong 60 giây (với z.ai)
 
-Mo trang web thuc hanh cua khoa hoc: [z.ai](https://chat.z.ai/). Trong bai nay, ta dung che do "phat trien full-stack" de xem AI tao du an va xem truoc ket qua.
+Mở trang web thực hành của khóa học: [z.ai](https://chat.z.ai/). Trong bài này, ta dùng chế độ "phát triển full-stack" để xem AI tạo dự án và xem trước kết quả.
 
-::: details Lap trinh ngay tren web la gi?
+::: details Lập trình ngay trên web là gì?
 
-Truoc day, lam mot app web thuong can:
+Trước đây, làm một app web thường cần:
 
-- cai moi truong (Node.js, Python),
-- cau hinh editor,
-- hoc HTML/CSS/JavaScript,
-- xu ly dependency va loi.
+- cài môi trường (Node.js, Python),
+- cấu hình editor,
+- học HTML/CSS/JavaScript,
+- xử lý dependency và lỗi.
 
-Gio day, voi nen tang lap trinh AI:
+Giờ đây, với nền tảng lập trình AI:
 
-- mo trinh duyet,
-- mo ta tinh nang bang ngon ngu tu nhien,
-- AI tu dong sinh code va xem truoc.
+- mở trình duyệt,
+- mô tả tính năng bằng ngôn ngữ tự nhiên,
+- AI tự động sinh code và xem trước.
 
-No chuyen trong tam tu "viet cu phap" sang "mo ta yeu cau".
+Nó chuyển trọng tâm từ "viết cú pháp" sang "mô tả yêu cầu".
 
 :::
 
 ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/index-2026-01-07-18-25-03.png)
 
-Dan yeu cau don gian nhu sau va chay:
+Đánh yêu cầu đơn giản như sau và chạy:
 
 ```txt
-Lam giup toi game Snake:
-1. Dieu khien bang phim mui ten
-2. An thuc an thi dai ra va tang diem
-3. Cham tuong hoac cham than thi Game Over
-4. Co nut bat dau va choi lai
-5. Giao dien gon va dep
+Làm giúp tôi game Snake:
+1. Điều khiển bằng phím mũi tên
+2. Ăn thức ăn thì dài ra và tăng điểm
+3. Chạm tường hoặc chạm thân thì Game Over
+4. Có nút bắt đầu và chơi lại
+5. Giao diện gọn và đẹp
 ```
 
 ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/index-2026-01-07-18-34-03.png)
 
-Khi xong, ban se thay trang web o ben phai. Thuong ban co the:
+Khi xong, bạn sẽ thấy trang web ở bên phải. Thường bạn có thể:
 
-- cuon de xem,
-- vao full-screen,
-- tai du an,
+- cuộn để xem,
+- vào full-screen,
+- tải dự án,
 - xem code.
 
 ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/index-2026-01-07-18-35-11.png)
 
-De xem ma nguon, bam vao bieu tuong code o goc tren ben phai.
+Để xem mã nguồn, bấm vào biểu tượng code ở góc trên bên phải.
 
 ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/image7.png)
 
-::: tip Thu them cong cu khac
+::: tip Thử thêm công cụ khác
 
-Ngoai z.ai, ban co the thu nhieu cong cu khac. Dieu quan trong khong phai ten cong cu, ma la vong lap:
+Ngoài z.ai, bạn có thể thử nhiều công cụ khác. Điều quan trọng không phải tên công cụ, mà là vòng lặp:
 
-1. mo ta yeu cau,
-2. thu chay,
-3. chi ro hien tuong sai,
-4. yeu cau sua cu the,
-5. lap lai.
+1. mô tả yêu cầu,
+2. thử chạy,
+3. chỉ rõ hiện tượng sai,
+4. yêu cầu sửa cụ thể,
+5. lặp lại.
 
 :::
 
-### 2.2 Lap trinh doi thoai lam duoc gi va khong lam duoc gi
+### 2.2 Lập trình đối thoại làm được gì và không làm được gì
 
-Tom tat thuc dung:
+Tóm tắt thực dụng:
 
-- AI rat gioi voi bai toan "nho va ro rang" neu ban mo ta UI va tuong tac cu the.
-- Voi du an lon, ban can goc nhin theo quy trinh: chia thanh buoc, dinh nghia input/output va giao cho AI lam tung phan.
-- "Viet duoc" khong dong nghia "dung duoc cho nguoi that". San xuat can test, bao mat va review.
+- AI rất giỏi với bài toán "nhỏ và rõ ràng" nếu bạn mô tả UI và tương tác cụ thể.
+- Với dự án lớn, bạn cần góc nhìn theo quy trình: chia thành bước, định nghĩa input/output và giao cho AI làm từng phần.
+- "Viết được" không đồng nghĩa "dùng được cho người thật". Sản xuất cần test, bảo mật và review.
 
-::: warning Huong dan theo tinh huong
+::: warning Hướng dẫn theo tình huống
 
-- **Prototype / demo / cong cu noi bo**: rat hop de AI lam ban dau, ban iter tiep.
-- **San pham lon cho nguoi dung that**: can dau tu dai han ve ky thuat.
-- **He thong yeu cau bao mat/tuân thu cao (thanh toan, y te, rui ro)**: khong nen "sinh xong la deploy", phai co quy trinh kiem tra nghiem ngat.
+- **Prototype / demo / công cụ nội bộ**: rất hợp để AI làm bản đầu, bạn iter tiếp.
+- **Sản phẩm lớn cho người dùng thật**: cần đầu tư dài hạn về kỹ thuật.
+- **Hệ thống yêu cầu bảo mật/tuân thủ cao (thanh toán, y tế, rủi ro)**: không nên "sinh xong là deploy", phải có quy trình kiểm tra nghiêm ngặt.
 
 :::
 
 <div style="margin: 50px 0;">
   <ClientOnly>
     <StepBar :active="2" :items="[
-      { title: 'Kho khan va co hoi', description: 'Mot cach moi de tao san pham' },
-      { title: 'Kham pha nhanh', description: 'Trai nghiem 60 giay' },
-      { title: 'Thuc hanh AI-native', description: 'Xay Snake AI-native' },
-      { title: 'Mo rong sang tao', description: 'Tu lam mot game khac' }
+      { title: 'Khó khăn và cơ hội', description: 'Một cách mới để tạo sản phẩm' },
+      { title: 'Khám phá nhanh', description: 'Trải nghiệm 60 giây' },
+      { title: 'Thực hành AI-native', description: 'Xây Snake AI-native' },
+      { title: 'Mở rộng sáng tạo', description: 'Tự làm một game khác' }
     ]" />
   </ClientOnly>
 </div>
 
-## 3. Thuc hanh: lam mot Snake "AI-native"
+## 3. Thực hành: làm một Snake "AI-native"
 
-"AI-native" o day nghia la: game khong chi la Snake co ban, ma co them mot kha nang AI gan vao gameplay. Vi du:
+"AI-native" ở đây nghĩa là: game không chỉ là Snake cơ bản, mà có thêm một khả năng AI gắn vào gameplay. Ví dụ:
 
-- an mot tu thi dich va tao vi du cau,
-- an mot chu de thi sinh ra mot cau/noi dung ngan,
-- an mot prompt thi sinh ra mot hinh.
+- ăn một từ thì dịch và tạo ví dụ câu,
+- ăn một chủ đề thì sinh ra một câu/nội dung ngắn,
+- ăn một prompt thì sinh ra một hình.
 
-Quan trong nhat la tap quy trinh: mo ta ro -> de AI lam -> thu chay -> sua theo ket qua.
+Quan trọng nhất là tập quy trình: mô tả rõ -> để AI làm -> thử chạy -> sửa theo kết quả.
 
-> Meo khi yeu cau sua:
+> Mẹo khi yêu cầu sửa:
 >
-> 1. mo ta hien tuong quan sat duoc,
-> 2. noi ro hanh vi ky vong,
-> 3. neu co loi, copy day du log/stack,
-> 4. yeu cau sua toi thieu can thiet.
+> 1. mô tả hiện tượng quan sát được,
+> 2. nói rõ hành vi kỳ vọng,
+> 3. nếu có lỗi, copy đầy đủ log/stack,
+> 4. yêu cầu sửa tối thiểu cần thiết.
 
-De theo doi trinh tu thuc hanh, ban se thay cac anh minh hoa:
+Để theo dõi trình tự thực hành, bạn sẽ thấy các ảnh minh họa:
 
 > ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/image12.png)
 >
@@ -187,39 +187,39 @@ De theo doi trinh tu thuc hanh, ban se thay cac anh minh hoa:
 
 ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/image15.png)
 
-Khi gap loi, dung doan. Hay copy loi va yeu cau AI giai thich bang ngon ngu don gian, sau do dua ra sua doi cu the.
+Khi gặp lỗi, đừng đoán. Hãy copy lỗi và yêu cầu AI giải thích bằng ngôn ngữ đơn giản, sau đó đưa ra sửa đổi cụ thể.
 
 ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/image56.png)
 ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/image57.png)
 ![](../../../zh-cn/stage-1/ai-capabilities-through-games/images/image58.png)
 
-## 4. Mo rong: tu lam mot mini game cua rieng ban
+## 4. Mở rộng: tự làm một mini game của riêng bạn
 
-Khi Snake da chay, muc tieu khong phai nho het code, ma la tao bien the.
+Khi Snake đã chạy, mục tiêu không phải nhớ hết code, mà là tạo biến thể.
 
-Goi y:
+Gợi ý:
 
-- game phan xa (bam dung thoi diem),
-- quiz tu vung,
-- dong ho dem nguoc voi phan thuong,
-- tao the (card) voi diem so.
+- game phản xạ (bấm đúng thời điểm),
+- quiz từ vựng,
+- đồng hồ đếm ngược với phần thưởng,
+- tạo thẻ (card) với điểm số.
 
-Buoc quan trong: dinh nghia vong lap cua game (input -> state -> output) roi moi nho AI implement.
+Bước quan trọng: định nghĩa vòng lặp của game (input -> state -> output) rồi mới nhờ AI implement.
 
 ![1767350588191](../../../zh-cn/stage-1/ai-capabilities-through-games/images/1767350588191.png)
 
-## Bai tap
+## Bài tập
 
-1. Lam lai Snake co ban voi mau sac va UI cua ban.
-2. Them it nhat 1 kha nang AI (dich, tom tat, sinh text...).
-3. Tu tao mot mini game/dem o don gian nhung choi duoc.
+1. Làm lại Snake cơ bản với màu sắc và UI của bạn.
+2. Thêm ít nhất 1 khả năng AI (dịch, tóm tắt, sinh text...).
+3. Tự tạo một mini game/demo đơn giản nhưng chơi được.
 
-## Buoc tiep theo
+## Bước tiếp theo
 
-O cac chuong tiep theo, ta se ket noi cac nang luc AI cu the hon (text-to-text, image-to-text, text-to-image) va tien toi cac du an day du hon.
+Ở các chương tiếp theo, ta sẽ kết nối các năng lực AI cụ thể hơn (text-to-text, image-to-text, text-to-image) và tiến tới các dự án đầy đủ hơn.
 
 <RelatedArticles :articles="relatedArticles" />
 ---
-title: 'So cap 1: Thoi dai AI, noi la lap trinh'
-description: 'Lam game ran AI-native bang doi thoai, sau do ap dung workflow de tao mini game hoac demo cua rieng ban.'
+title: 'Sơ cấp 1: Thời đại AI, nói là lập trình'
+description: 'Làm game rắn AI-native bằng đối thoại, sau đó áp dụng workflow để tạo mini game hoặc demo của riêng bạn.'
 ---

--- a/docs/vi-vn/stage-1/appendix-a-product-thinking/index.md
+++ b/docs/vi-vn/stage-1/appendix-a-product-thinking/index.md
@@ -1,152 +1,151 @@
 ---
-title: 'Tu duy san pham va thiet ke giai phap'
-description: 'Chuyen tu "lam tool" sang "lam san pham": nguon y tuong, cach tach nho thanh MVP, cai thien trai nghiem va dung AI de tang gia tri.'
+title: 'Tư duy sản phẩm và thiết kế giải pháp'
+description: 'Chuyển từ "làm tool" sang "làm sản phẩm": nguồn ý tưởng, cách tách nhỏ thành MVP, cải thiện trải nghiệm và dùng AI để tăng giá trị.'
 ---
 
 <script setup>
-const duration = 'Khoang <strong>6 gio</strong>'
+const duration = 'Khoảng <strong>6 giờ</strong>'
 </script>
 
-# Tu duy san pham va thiet ke giai phap
+# Tư duy sản phẩm và thiết kế giải pháp
 
-## Gioi thieu chuong
+## Giới thiệu chương
 
-<ChapterIntroduction :duration="duration" :tags="['Tu duy san pham', 'Phan tich nhu cau', 'Thiet ke giai phap', 'Hieu nguoi dung']" coreOutput="1 ban phac thao san pham hoan chinh" expectedOutput="Huong san pham co the trien khai">
+<ChapterIntroduction :duration="duration" :tags="['Tư duy sản phẩm', 'Phân tích nhu cầu', 'Thiết kế giải pháp', 'Hiểu người dùng']" coreOutput="1 bản phác thảo sản phẩm hoàn chỉnh" expectedOutput="Hướng sản phẩm có thể triển khai">
 
-O cac chuong truoc, ban da quen voi viec dung AI IDE de lam prototype va cac tool nho. Phan nay tap trung vao cau hoi lon hon: <strong>"Lam gi thi dang?"</strong>
+Ở các chương trước, bạn đã quen với việc dùng AI IDE để làm prototype và các tool nhỏ. Phần này tập trung vào câu hỏi lớn hơn: <strong>"Làm gì thì đáng?"</strong>
 
-Muc tieu:
+Mục tiêu:
 
-1. Tim y tuong dang tin hon (khong chi la cam hung).
-2. Bien y tuong thanh mot flow co the build.
-3. Di tu "chay duoc" sang "nguoi ta thich dung".
-4. Dung AI o dung cho, de tang gia tri that.
+1. Tìm ý tưởng đáng tin hơn (không chỉ là cảm hứng).
+2. Biến ý tưởng thành một flow có thể build.
+3. Đi từ "chạy được" sang "người ta thích dùng".
+4. Dùng AI ở đúng chỗ, để tăng giá trị thật.
 
 </ChapterIntroduction>
 
 <div style="margin: 50px 0;">
   <ClientOnly>
     <StepBar :active="0" :items="[
-      { title: 'Nguon y tuong', description: 'Tim y tuong dang tin' },
-      { title: 'Tach nho giai phap', description: 'Bien y tuong thanh app co the lam' },
-      { title: 'Danh gia va cai thien', description: 'Tu dung duoc den dung suong' },
-      { title: 'AI phong dai gia tri', description: 'Dung AI hop ly' }
+      { title: 'Nguồn ý tưởng', description: 'Tìm ý tưởng đáng tin' },
+      { title: 'Tách nhỏ giải pháp', description: 'Biến ý tưởng thành app có thể làm' },
+      { title: 'Đánh giá và cải thiện', description: 'Từ dùng được đến dùng sâu' },
+      { title: 'AI phóng đại giá trị', description: 'Dùng AI hợp lý' }
     ]" />
   </ClientOnly>
 </div>
 
-## Ban se hoc duoc gi
+## Bạn sẽ học được gì
 
-Sau phan nay, ban co the tra loi:
+Sau phần này, bạn có thể trả lời:
 
-1. Y tuong den tu dau thi on?
-2. Tach y tuong ra sao de lam MVP?
-3. Lam sao de biet app co tot khong va cach nang cap?
-4. Dung AI o buoc nao de tang gia tri?
-5. Tim nguoi dung dau tien nhu the nao?
+1. Ý tưởng đến từ đâu thì ổn?
+2. Tách ý tưởng ra sao để làm MVP?
+3. Làm sao để biết app có tốt không và cách nâng cấp?
+4. Dùng AI ở bước nào để tăng giá trị?
+5. Tìm người dùng đầu tiên như thế nào?
 
 ---
 
-# 1. Nguon y tuong dang tin
+# 1. Nguồn ý tưởng đáng tin
 
-Ban khong can "y tuong sieu doc". Ban can van de that, lap lai, trong boi canh ro rang.
+Bạn không cần "ý tưởng siêu độc". Bạn cần vấn đề thật, lặp lại, trong bối cảnh rõ ràng.
 
-## 1.1 The nao la mot y tuong (theo goc san pham)?
+## 1.1 Thế nào là một ý tưởng (theo góc sản phẩm)?
 
-Mot y tuong co the build can:
+Một ý tưởng có thể build cần:
 
-1. Nguoi dung muc tieu ro rang (ai?).
-2. Tinh huong cu the (khi nao/o dau?).
-3. Nhiem vu cu the (muon dat ket qua gi?).
-4. Cai tien hop ly so voi cach lam hien tai.
+1. Người dùng mục tiêu rõ ràng (ai?).
+2. Tình huống cụ thể (khi nào/ở đâu?).
+3. Nhiệm vụ cụ thể (muốn đạt kết quả gì?).
+4. Cải tiến hợp lý so với cách làm hiện tại.
 
-## 1.2 Y tuong vs nhu cau that
+## 1.2 Ý tưởng vs nhu cầu thật
 
-Y tuong la gia thuyet. Nhu cau that la thu nguoi dung dang tu tim cach giai (du la workaround).
+Ý tưởng là giả thuyết. Nhu cầu thật là thứ người dùng đang tự tìm cách giải (dù là workaround).
 
-Quy tac nhanh:
+Quy tắc nhanh:
 
-- Nhu cau that: nguoi dung dang tra gia bang thoi gian/tien/cong suc.
-- Nhu cau gia: nghe hay nhung khong doi hanh vi, khong tra tien.
+- Nhu cầu thật: người dùng đang trả giá bằng thời gian/tiền/công sức.
+- Nhu cầu giả: nghe hay nhưng không đổi hành vi, không trả tiền.
 
 ![](../../../zh-cn/stage-1/appendix-a-product-thinking/images/image2.png)
 
-## 1.3 Vi sao co y tuong tu nhien tang truong
+## 1.3 Vì sao có ý tưởng tự nhiên tăng trưởng
 
-Neu gia tri den nhanh va flow ngan, nguoi dung se tu gioi thieu:
+Nếu giá trị đến nhanh và flow ngắn, người dùng sẽ tự giới thiệu:
 
-Van de -> gia tri nho ngay lap tuc -> lap lai -> gioi thieu.
+Vấn đề -> giá trị nhỏ ngay lập tức -> lặp lại -> giới thiệu.
 
-Neu can "keo" lien tuc bang quang cao va giai thich, thuong la dau hieu pain chua du manh.
+Nếu cần "kéo" liên tục bằng quảng cáo và giải thích, thường là dấu hiệu pain chưa đủ mạnh.
 
-## 1.4 4 nguon y tuong on dinh
+## 1.4 4 nguồn ý tưởng ổn định
 
-1. Cong viec hang ngay: quy trinh lap, bao cao, phoi hop, QA.
-2. Cong dong: cau hoi lap lai, van de nhieu nguoi gap.
-3. Review/binh luan: ma sat, buc xuc "sao kho vay?".
-4. San pham co san: tim lo hong (qua dat, qua phuc tap, thieu chuyen sau).
+1. Công việc hàng ngày: quy trình lặp, báo cáo, phối hợp, QA.
+2. Cộng đồng: câu hỏi lặp lại, vấn đề nhiều người gặp.
+3. Review/bình luận: phàn nàn, bức xúc "sao khó vậy?".
+4. Sản phẩm có sẵn: tìm lỗ hổng (quá đắt, quá phức tạp, thiếu chuyên sâu).
 
 ![](../../../zh-cn/stage-1/appendix-a-product-thinking/images/image3.png)
 
 ---
 
-# 2. Tach nho: tu y tuong thanh app
+# 2. Tách nhỏ: từ ý tưởng thành app
 
-Y tuong chi build duoc khi chuyen thanh quyet dinh.
+Ý tưởng chỉ build được khi chuyển thành quyết định.
 
-## 2.1 Toi thieu: nguoi dung, tinh huong, flow
+## 2.1 Tối thiểu: người dùng, tình huống, flow
 
-Xac dinh:
+Xác định:
 
-1. Nguoi dung: vai tro, muc tieu, rang buoc, kha nang chi tra.
-2. Tinh huong: trigger -> cac buoc -> ket qua.
-3. Flow chinh: 3-7 buoc de tao gia tri.
+1. Người dùng: vai trò, mục tiêu, ràng buộc, khả năng chi trả.
+2. Tình huống: trigger -> các bước -> kết quả.
+3. Flow chính: 3–7 bước để tạo giá trị.
 
-## 2.2 Cat scope (MVP)
+## 2.2 Cắt scope (MVP)
 
-MVP khong phai "it feature", ma la "loi hua ro rang va lam duoc".
+MVP không phải "ít feature", mà là "lời hứa rõ ràng và làm được".
 
-Cau hoi:
+Câu hỏi:
 
-- Phut dau tien nao nguoi dung thay "co loi"?
-- Cat gi ma khong lam mat gia tri cot loi?
-- Gia thuyet rui ro nhat la gi? (can validate som)
-
----
-
-# 3. Cai thien: tu dung duoc den dung suong
-
-Sau khi co ban dau, tap trung vao:
-
-1. Ro rang: nguoi moi biet lam gi tiep theo.
-2. It ma sat: it click, it form, it doi.
-3. Tao tin tuong: ket qua giai thich duoc, default an toan.
-
-Test nhanh: nguoi moi co the nhan gia tri trong 60 giay khong?
+- Phút đầu tiên nào người dùng thấy "có lợi"?
+- Cắt gì mà không làm mất giá trị cốt lõi?
+- Giả thuyết rủi ro nhất là gì? (cần validate sớm)
 
 ---
 
-# 4. Dung AI de phong dai gia tri
+# 3. Cải thiện: từ dùng được đến dùng sâu
 
-AI manh nhat khi:
+Sau khi có bản đầu, tập trung vào:
 
-1. Bien ngon ngu thanh cau truc (text -> task, note -> plan).
-2. Tom tat va uu tien (nhieu thong tin -> hanh dong).
-3. Ca nhan hoa (goi y theo boi canh).
+1. Rõ ràng: người mới biết làm gì tiếp theo.
+2. Ít ma sát: ít click, ít form, ít đợi.
+3. Tạo tin tưởng: kết quả giải thích được, default an toàn.
 
-AI yeu khi chi "dan chat" ma khong cai thien flow cot loi.
+Test nhanh: người mới có thể nhận giá trị trong 60 giây không?
 
 ---
 
-## Output mong doi
+# 4. Dùng AI để phóng đại giá trị
 
-Mot ban phac thao san pham gom:
+AI mạnh nhất khi:
 
-1. Nguoi dung va use-case
-2. Van de cot loi va chi phi hien tai
-3. Flow chinh (3-7 buoc)
+1. Biến ngôn ngữ thành cấu trúc (text -> task, note -> plan).
+2. Tóm tắt và ưu tiên (nhiều thông tin -> hành động).
+3. Cá nhân hóa (gợi ý theo bối cảnh).
+
+AI yếu khi chỉ "dán chat" mà không cải thiện flow cốt lõi.
+
+---
+
+## Output mong đợi
+
+Một bản phác thảo sản phẩm gồm:
+
+1. Người dùng và use-case
+2. Vấn đề cốt lõi và chi phí hiện tại
+3. Flow chính (3–7 bước)
 4. Scope MVP
-5. Ke hoach validate (7 ngay) va metric
+5. Kế hoạch validate (7 ngày) và metric
 
 <RelatedArticlesSection />
-

--- a/docs/vi-vn/stage-1/finding-great-idea/index.md
+++ b/docs/vi-vn/stage-1/finding-great-idea/index.md
@@ -1,206 +1,206 @@
 ---
-title: 'Tim y tuong tot - tu nhu cau nguoi dung den san pham co nguoi tra tien'
-description: 'Hoc cach phat hien co hoi tu nhung noi dau hang ngay, phan tich nhu cau co he thong, va mai dua mot y tuong binh thuong thanh khai niem san pham ma nguoi dung san sang tra tien.'
+title: 'Tìm ý tưởng tốt - từ nhu cầu người dùng đến sản phẩm có người trả tiền'
+description: 'Học cách phát hiện cơ hội từ những nỗi đau hàng ngày, phân tích nhu cầu có hệ thống, và mài giũa một ý tưởng bình thường thành khái niệm sản phẩm mà người dùng sẵn sàng trả tiền.'
 ---
 
 <script setup>
-const duration = 'Khoang <strong>3 gio</strong>'
+const duration = 'Khoảng <strong>3 giờ</strong>'
 </script>
 
-# So cap 2: Tim y tuong tot
+# Sơ cấp 2: Tìm ý tưởng tốt
 
-## Dan nhap chuong
+## Dẫn nhập chương
 
-<ChapterIntroduction :duration="duration" :tags="['Khai pha nhu cau', 'Tu duy san pham', 'Phan tich nguoi dung', 'Mo hinh kinh doanh']" coreOutput="3 khai niem san pham da duoc kiem chung" expectedOutput="Huong san pham/co hoi khoi nghiep co the trien khai">
+<ChapterIntroduction :duration="duration" :tags="['Khám phá nhu cầu', 'Tư duy sản phẩm', 'Phân tích người dùng', 'Mô hình kinh doanh']" coreOutput="3 khái niệm sản phẩm đã được kiểm chứng" expectedOutput="Hướng sản phẩm/cơ hội khởi nghiệp có thể triển khai">
 
-O chuong truoc, ban da thay AI IDE co the giup ta tao ra san pham rat nhanh. Nhung truoc khi viet dong code dau tien, co mot cau hoi can ban hon:
+Ở chương trước, bạn đã thấy AI IDE có thể giúp ta tạo ra sản phẩm rất nhanh. Nhưng trước khi viết dòng code đầu tiên, có một câu hỏi cần hơn:
 
-<strong>Minh se lam cai gi?</strong>
+<strong>Mình sẽ làm cái gì?</strong>
 
-Rat nhieu nguoi bat dau bang "lam mot cong cu AI" hoac "lam mot mang xa hoi", nhung lam xong thi khong ai dung. Van de thuong nam o dau? <strong>Chua tim duoc nhu cau that.</strong>
+Rất nhiều người bắt đầu bằng "làm một công cụ AI" hoặc "làm một mạng xã hội", nhưng làm xong thì không ai dùng. Vấn đề thường nằm ở đâu? <strong>Chưa tìm được nhu cầu thật.</strong>
 
-Thuc te con kho hon: <strong>co san pham giai quyet dung van de nhung nguoi dung van khong muon tra tien</strong>.
+Thực tế còn khó hơn: <strong>có sản phẩm giải quyết đúng vấn đề nhưng người dùng vẫn không muốn trả tiền</strong>.
 
-Trong chuong nay, thong qua cau chuyen cua Minh, ban se hoc mot phuong phap hoan chinh de tim y tuong: tu tieu chuan danh gia, khai pha noi dau, phan nhom nguoi dung, dao sau boi canh, kiem chung nhu cau, va mai dua khai niem san pham.
+Trong chương này, thông qua câu chuyện của Minh, bạn sẽ học một phương pháp hoàn chỉnh để tìm ý tưởng: từ tiêu chuẩn đánh giá, khai phá nỗi đau, phân nhóm người dùng, đào sâu bối cảnh, kiểm chứng nhu cầu, và mài giũa khái niệm sản phẩm.
 
 </ChapterIntroduction>
 
 <div style="margin: 50px 0;">
   <ClientOnly>
     <StepBar :active="0" :items="[
-      { title: 'Step 1', description: 'Xay tieu chuan danh gia' },
-      { title: 'Step 2', description: 'Khai pha noi dau hang ngay' },
-      { title: 'Step 3', description: 'Phan nhom nguoi dung theo chieu ngang' },
-      { title: 'Step 4', description: 'Dao sau boi canh theo chieu doc' },
-      { title: 'Step 5', description: 'Kiem chung nhu cau that/gia' },
-      { title: 'Step 6', description: 'Mai dua khai niem san pham' }
+      { title: 'Step 1', description: 'Xây tiêu chuẩn đánh giá' },
+      { title: 'Step 2', description: 'Khám phá nỗi đau hàng ngày' },
+      { title: 'Step 3', description: 'Phân nhóm người dùng theo chiều ngang' },
+      { title: 'Step 4', description: 'Đào sâu bối cảnh theo chiều dọc' },
+      { title: 'Step 5', description: 'Kiểm chứng nhu cầu thật/gia' },
+      { title: 'Step 6', description: 'Mài giũa khái niệm sản phẩm' }
     ]" />
   </ClientOnly>
 </div>
 
-## Step 1: Xay tieu chuan danh gia - nhu cau nao khien nguoi dung san sang tra tien
+## Step 1: Xây tiêu chuẩn đánh giá - nhu cầu nào khiến người dùng sẵn sàng trả tiền
 
-::: warning Vi sao chuong nay quan trong?
+::: warning Vì sao chương này quan trọng?
 
-Co the ban se nghi: "Day la khoa hoc Vibe Coding, sao lai hoc tim nhu cau truoc? Khong viet code luon duoc a?"
+Có thể bạn sẽ nghĩ: "Đây là khóa học Vibe Coding, sao lại học tìm nhu cầu trước? Không viết code luôn được à?"
 
-Rat nhieu khoa hoc lap trinh bat dau bang du an: Todo List, may tinh, blog ca nhan... Nhung neu huong di sai, ban cang lam nhieu cang xa muc tieu.
+Rất nhiều khóa học lập trình bắt đầu bằng dự án: Todo List, máy tính, blog cá nhân... Nhưng nếu hướng đi sai, bạn càng làm nhiều càng xa mục tiêu.
 
-Hay tuong tuong:
+Hãy tưởng tượng:
 
-- Ban bo 2 tuan lam "he thong quan ly lich", trong khi thi truong da co hang tram san pham tot hon.
-- Ban lam app "chup anh tinh calo", nhung nguoi dung dung 1 lan roi go.
-- Ban lam "so chi tieu ca nhan", nhung chinh ban cung it dung.
+- Bạn bỏ 2 tuần làm "hệ thống quản lý lịch", trong khi thị trường đã có hàng trăm sản phẩm tốt hơn.
+- Bạn làm app "chụp ảnh tính calo", nhưng người dùng dùng 1 lần rồi bỏ.
+- Bạn làm "sổ chi tiêu cá nhân", nhưng chính bạn cũng ít dùng.
 
-Lam xong, ban co cam thay tu tin de coi do la "mot san pham dang gia" khong? Thuong la khong, vi no khong giai quyet van de that, khong tao gia tri that.
+Làm xong, bạn có cảm thấy tự tin để coi đó là "một sản phẩm đáng giá" không? Thường là không, vì nó không giải quyết vấn đề thật, không tạo giá trị thật.
 
-Vibe Coding lam cho viec bien y tuong thanh san pham nhanh hon. Chinh vi nhanh, ta can biet <strong>chuyen gi dang lam</strong>.
-
-:::
-
-### Tieu chuan danh gia y tuong (ban nen ghi ra)
-
-Mot y tuong "dang lam" thuong can dat toi thieu 4 tieu chuan:
-
-1. **Co nguoi gap van de thuong xuyen**: khong phai mot tinh huong hiem.
-2. **Van de co gia tri**: tiet kiem thoi gian, tien bac, rui ro, hoac giam dau dau.
-3. **Nguoi dung co dong luc hanh dong**: ho san sang thay doi hanh vi de giai quyet.
-4. **Ban co cach tiep can**: ban biet tim nguoi dung o dau va co the lay phan hoi.
-
-Neu y tuong chi "nghe hay" nhung khong ro ai can, can nhu the nao, va vi sao ho tra tien, thi rat de lam xong roi... khong ai dung.
-
-## Mo dau: cau chuyen cua Minh
-
-Minh la mot lap trinh vien da di lam 3 nam. Mot ngay, Minh nghi: "Hay lam mot app the hinh giup nguoi dung len ke hoach tap va ghi lai du lieu tap luyen." Minh rat hao hung vi cam thay minh tim duoc mot du an lon.
-
-Mot nam tiep theo, Minh danh het thoi gian ranh de lam app: khoa hoc, check-in, cong dong, phan tich du lieu... giao dien cung dep (theo Minh thay).
-
-Ngay ra mat, Minh chi tien quang ba. Thang dau co 50.000 luot tai. Nghe co ve tot.
-
-Nhung van de den nhanh:
-
-- Nguoi dung tai ve dung 1 lan roi go.
-- Ty le quay lai sau 7 ngay rat thap.
-- Tinh nang tra phi gan nhu khong ai mua.
-- Thi truong da co san pham truong thanh voi noi dung va he sinh thai manh.
-
-Minh lo nang va tu hoi: "Minh lam cung on ma, sao khong ai dung?"
-
-Van de khong phai Minh thieu ky thuat. Van de nam o **diem xuat phat**: Minh chua lam ro cau hoi can ban nhat: <strong>nguoi dung co that su can them mot app nay khong, va vi sao ho se tra tien?</strong>
-
-Tu do, ta rut ra bai hoc: <strong>huong di sai thi cang di sau cang sai</strong>.
-
-::: tip Chuong nay ban se lam gi?
-
-Ban se di qua 3 man:
-
-1. Tim nhu cau that: nhu cau nao co gia tri va co the tra tien.
-2. Dao ra y tuong tot: tu noi dau hang ngay tao thanh co hoi san pham.
-3. Mai dua bang AI: dung AI de bien y tuong thanh phuong an co the trien khai va kiem chung.
+Vibe Coding làm cho việc biến ý tưởng thành sản phẩm nhanh hơn. Chính vì nhanh, ta cần biết <strong>chọn gì đáng làm</strong>.
 
 :::
 
-## Step 2: Khai pha noi dau hang ngay
+### Tiêu chuẩn đánh giá ý tưởng (bạn nên ghi ra)
 
-Nguon y tuong on dinh nhat thuong den tu "noi dau hang ngay". Cach lam don gian:
+Một ý tưởng "đáng làm" thường cần đạt tối thiểu 4 tiêu chuẩn:
 
-1. Viet ra 20 viec/boi canh ban (hoac nguoi xung quanh) lap lai hang tuan.
-2. Danh dau nhung cho "mat thoi gian", "de sai", "de quen", "de tre han", "de bi phat".
-3. Moi muc, ghi them: ai dang bi dau dau? khi nao? tai sao? hau qua la gi?
+1. **Có người gặp vấn đề thường xuyên**: không phải một tình huống hiếm.
+2. **Vấn đề có giá trị**: tiết kiệm thời gian, tiền bạc, rủi ro, hoặc giảm đau đầu.
+3. **Người dùng có động lực hành động**: họ sẵn sàng thay đổi hành vi để giải quyết.
+4. **Bạn có cách tiếp cận**: bạn biết tìm người dùng ở đâu và có thể lấy phản hồi.
 
-Vi du noi dau:
+Nếu ý tưởng chỉ "nghe hay" nhưng không rõ ai cần, cần như thế nào, và vì sao họ trả tiền, thì rất dễ làm xong rồi... không ai dùng.
 
-- Lam bao cao hang tuan mat nhieu thoi gian.
-- Chat voi khach hang qua nhieu kenh, bi sot tin.
-- Sap xep tai lieu/anh/video rui tung, moi lan tim rat lau.
-- Duyet hop dong dai, de bo sot rui ro.
+## Mở đầu: câu chuyện của Minh
 
-Quan trong: dung dung o "van de" chung chung. Hay dich no thanh hanh vi va boi canh cu the.
+Minh là một lập trình viên đã đi làm 3 năm. Một ngày, Minh nghĩ: "Hãy làm một app thể hình giúp người dùng lên kế hoạch tập và ghi lại dữ liệu tập luyện." Minh rất hào hứng vì cảm thấy mình tìm được một dự án lớn.
 
-## Step 3: Phan nhom nguoi dung theo chieu ngang
+Một năm tiếp theo, Minh dành hết thời gian rảnh để làm app: khóa học, check-in, cộng đồng, phân tích dữ liệu... giao diện cũng đẹp (theo Minh thấy).
 
-Mot y tuong co the dung voi nhieu nhom nguoi, nhung moi nhom co "gia tri" va "kha nang tra tien" khac nhau.
+Ngày ra mắt, Minh chi tiền quảng cáo. Tháng đầu có 50.000 lượt tải. Nghe có vẻ tốt.
 
-Hay phan nhom theo:
+Nhưng vấn đề đến nhanh:
 
-- Nghe nghiep/vi tri: van hanh, ke toan, HR, sales, giao vien, sinh vien...
-- Quy mo: ca nhan, nhom nho, doanh nghiep.
-- Tan suat: dung hang ngay hay thinh thoang?
-- Chi phi cua van de: mat 10 phut hay mat 5 gio?
+- Người dùng tải về dùng 1 lần rồi bỏ.
+- Tỷ lệ quay lại sau 7 ngày rất thấp.
+- Tính năng trả phí gần như không ai mua.
+- Thị trường đã có sản phẩm trưởng thành với nội dung và hệ sinh thái mạnh.
 
-Muc tieu cua buoc nay: chon ra 1-2 nhom ma ban co the tiep can de phong van va kiem chung.
+Minh lo lắng và tự hỏi: "Mình làm cũng ổn mà, sao không ai dùng?"
 
-## Step 4: Dao sau boi canh theo chieu doc
+Vấn đề không phải Minh thiếu kỹ thuật. Vấn đề nằm ở **điểm xuất phát**: Minh chưa làm rõ câu hỏi cần thiết nhất: <strong>người dùng có thực sự cần thêm một app này không, và vì sao họ sẽ trả tiền?</strong>
 
-De mo ta ro nhu cau, ban can biet:
+Từ đó, ta rút ra bài học: <strong>huống đi sai thì càng đi sâu càng sai</strong>.
 
-1. Nguoi dung bat dau tu dau? (dau vao)
-2. Ho thuong lam gi tiep theo? (cac buoc)
-3. Cho nao hay bi ket? (nut that)
-4. Sai sot thuong xay ra o dau? (rui ro)
-5. Sau khi xong, ho can dau ra gi? (ket qua)
+::: tip Chương này bạn sẽ làm gì?
 
-De lam nhanh, hay ve 1 "luong cong viec" gom 5-7 buoc. AI rat hop de giup ban sap xep va lam ro luong nay.
+Bạn sẽ đi qua 3 màn:
 
-## Step 5: Kiem chung nhu cau that/gia
+1. Tìm nhu cầu thật: nhu cầu nào có giá trị và có thể trả tiền.
+2. Đào ra ý tưởng tốt: từ nỗi đau hàng ngày tạo thành cơ hội sản phẩm.
+3. Mài giũa bằng AI: dùng AI để biến ý tưởng thành phương án có thể triển khai và kiểm chứng.
 
-Nhieu y tuong nghe co ve hop ly nhung thuc ra la "nhu cau gia". Cach kiem chung:
+:::
 
-- **Hoi ve hanh vi qua khu** thay vi y kien chung chung.
-- **Hoi chi tiet chi phi**: mat bao lau, mat bao nhieu tien, bi anh huong ra sao.
-- **Hoi giai phap hien tai**: ho dang dung gi de giai quyet? co phai ho da tu lam cach khac?
-- **Hoi nguong tra tien**: trong tinh huong nao ho san sang tra?
+## Step 2: Khám phá nỗi đau hàng ngày
 
-Goi y cau hoi phong van:
+Nguồn ý tưởng ổn định nhất thường đến từ "nỗi đau hàng ngày". Cách làm đơn giản:
 
-1. Lan gan nhat ban gap van de nay la khi nao? Ban dang lam gi?
-2. Ban da thu giai phap nao? Vi sao khong on?
-3. Neu giai quyet duoc, ban duoc loi gi? (thoi gian, tien, rui ro, tinh than)
-4. Neu co cong cu giai quyet, ban muon no lam gi truoc? Cai gi la "bat buoc"?
+1. Viết ra 20 việc/bối cảnh bạn (hoặc người xung quanh) lặp lại hàng tuần.
+2. Đánh dấu những chỗ "mất thời gian", "dễ sai", "dễ quên", "dễ trễ hạn", "dễ bị phạt".
+3. Mỗi mục, ghi thêm: ai đang bị đau đầu? khi nào? tại sao? hậu quả là gì?
 
-## Step 6: Mai dua khai niem san pham
+Ví dụ nỗi đau:
 
-Den day, ban co 3 thanh phan:
+- Làm báo cáo hàng tuần mất nhiều thời gian.
+- Chat với khách hàng qua nhiều kênh, bị sót tin.
+- Sắp xếp tài liệu/ảnh/video rời rạc, mỗi lần tìm rất lâu.
+- Duyệt hợp đồng dài, dễ bỏ sót rủi ro.
 
-1. Mot nhom nguoi dung ro rang.
-2. Mot boi canh ro rang.
-3. Mot noi dau ro rang va co chi phi.
+Quan trọng: đừng dừng ở "vấn đề" chung chung. Hãy dịch nó thành hành vi và bối cảnh cụ thể.
 
-Gio hay viet 1 cau "dinh nghia san pham" theo mau:
+## Step 3: Phân nhóm người dùng theo chiều ngang
 
-> Doi voi [nhom nguoi dung], trong boi canh [tinh huong cu the], san pham nay giup ho [muc tieu] bang cach [cach lam], de giam [chi phi] va dat duoc [ket qua].
+Một ý tưởng có thể dùng cho nhiều nhóm người, nhưng mỗi nhóm có "giá trị" và "khả năng trả tiền" khác nhau.
 
-Vi du:
+Hãy phân nhóm theo:
 
-> Doi voi nhan vien van hanh TMĐT, khi can tao nhanh noi dung cho nhieu san pham, cong cu nay giup tao ban nhap anh va copy theo mau, de giam thoi gian lam thu cong va tang toc do len hang.
+- Nghề nghiệp/vị trí: vận hành, kế toán, HR, sales, giáo viên, sinh viên...
+- Quy mô: cá nhân, nhóm nhỏ, doanh nghiệp.
+- Tần suất: dùng hàng ngày hay thỉnh thoảng?
+- Chi phí của vấn đề: mất 10 phút hay mất 5 giờ?
 
-### Dung AI de mai dua (prompt mau)
+Mục tiêu của bước này: chọn ra 1–2 nhóm mà bạn có thể tiếp cận để phỏng vấn và kiểm chứng.
 
-Ban co the dua y tuong cho AI de:
+## Step 4: Đào sâu bối cảnh theo chiều dọc
 
-- viet lai mo ta cho ro rang hon,
-- de xuat 3 phien ban "dinh vi san pham" khac nhau,
-- de xuat 10 cau hoi phong van,
-- de xuat 3 gia thuyet nguoi dung va cach test.
+Để mô tả rõ nhu cầu, bạn cần biết:
 
-Prompt goi y:
+1. Người dùng bắt đầu từ đâu? (đầu vào)
+2. Họ thường làm gì tiếp theo? (các bước)
+3. Chỗ nào hay bị kẹt? (nút thắt)
+4. Sai sót thường xảy ra ở đâu? (rủi ro)
+5. Sau khi xong, họ cần đầu ra gì? (kết quả)
+
+Để làm nhanh, hãy vẽ 1 "luồng công việc" gồm 5–7 bước. AI rất hợp để giúp bạn sắp xếp và làm rõ luồng này.
+
+## Step 5: Kiểm chứng nhu cầu thật/gia
+
+Nhiều ý tưởng nghe có vẻ hợp lý nhưng thực ra là "nhu cầu giả". Cách kiểm chứng:
+
+- **Hỏi về hành vi quá khứ** thay vì ý kiến chung chung.
+- **Hỏi chi tiết chi phí**: mất bao lâu, mất bao nhiêu tiền, bị ảnh hưởng ra sao.
+- **Hỏi giải pháp hiện tại**: họ đang dùng gì để giải quyết? có phải họ đã tự làm cách khác?
+- **Hỏi ngưỡng trả tiền**: trong tình huống nào họ sẵn sàng trả?
+
+Gợi ý câu hỏi phỏng vấn:
+
+1. Lần gần nhất bạn gặp vấn đề này là khi nào? Bạn đang làm gì?
+2. Bạn đã thử giải pháp nào? Vì sao không ổn?
+3. Nếu giải quyết được, bạn được lợi gì? (thời gian, tiền, rủi ro, tinh thần)
+4. Nếu có công cụ giải quyết, bạn muốn nó làm gì trước? Cái gì là "bắt buộc"?
+
+## Step 6: Mài giũa khái niệm sản phẩm
+
+Đến đây, bạn có 3 thành phần:
+
+1. Một nhóm người dùng rõ ràng.
+2. Một bối cảnh rõ ràng.
+3. Một nỗi đau rõ ràng và có chi phí.
+
+Giờ hãy viết 1 câu "định nghĩa sản phẩm" theo mẫu:
+
+> Đối với [nhóm người dùng], trong bối cảnh [tình huống cụ thể], sản phẩm này giúp họ [mục tiêu] bằng cách [cách làm], để giảm [chi phí] và đạt được [kết quả].
+
+Ví dụ:
+
+> Đối với nhân viên vận hành TMĐT, khi cần tạo nhanh nội dung cho nhiều sản phẩm, công cụ này giúp tạo bản nháp ảnh và copy theo mẫu, để giảm thời gian làm thủ công và tăng tốc độ lên hàng.
+
+### Dùng AI để mài giũa (prompt mẫu)
+
+Bạn có thể đưa ý tưởng cho AI để:
+
+- viết lại mô tả cho rõ ràng hơn,
+- đề xuất 3 phiên bản "định vị sản phẩm" khác nhau,
+- đề xuất 10 câu hỏi phỏng vấn,
+- đề xuất 3 giả thuyết người dùng và cách test.
+
+Prompt gợi ý:
 
 ```txt
-Toi co y tuong san pham sau:
-[dan noi dung o day]
+Tôi có ý tưởng sản phẩm sau:
+[dán nội dung ở đây]
 
-Hay giup toi:
-1. Viet lai thanh 1 cau mo ta ro rang (1-2 cau).
-2. Liet ke 5 tinh huong nguoi dung that su gap van de.
-3. Viet 10 cau hoi phong van de kiem chung.
-4. De xuat 3 phien ban dinh vi san pham khac nhau.
+Hãy giúp tôi:
+1. Viết lại thành 1 câu mô tả rõ ràng (1–2 câu).
+2. Liệt kê 5 tình huống người dùng thực sự gặp vấn đề.
+3. Viết 10 câu hỏi phỏng vấn để kiểm chứng.
+4. Đề xuất 3 phiên bản định vị sản phẩm khác nhau.
 ```
 
-## Bai tap
+## Bài tập
 
-1. Viet ra 10 noi dau hang ngay ban gap (hoac nguoi than ban be gap).
-2. Chon 2 noi dau co chi phi ro rang va co nguoi co the phong van ngay.
-3. Viet 1 cau "dinh nghia san pham" theo mau o tren.
-4. Viet 10 cau hoi phong van va phong van it nhat 1 nguoi that.
+1. Viết ra 10 nỗi đau hàng ngày bạn gặp (hoặc người thân bạn bè gặp).
+2. Chọn 2 nỗi đau có chi phí rõ ràng và có người có thể phỏng vấn ngay.
+3. Viết 1 câu "định nghĩa sản phẩm" theo mẫu ở trên.
+4. Viết 10 câu hỏi phỏng vấn và phỏng vấn ít nhất 1 người thật.
 
-Khi ban co 3 phan: nguoi dung + boi canh + noi dau, viec dung AI IDE de tao prototype se de hon rat nhieu.
+Khi bạn có 3 phần: người dùng + bối cảnh + nỗi đau, việc dùng AI IDE để tạo prototype sẽ dễ hơn rất nhiều.


### PR DESCRIPTION
Fixes #117

## What this PR does

The Vietnamese translation files in docs/vi-vn/ are missing all Vietnamese diacritical marks (dấu). This PR adds proper accents throughout the affected files.

### Files changed

1. `stage-1/ai-capabilities-through-games/index.md` (206 lines)
2. `stage-1/finding-great-idea/index.md` (119 lines)
3. `stage-1/appendix-a-product-thinking/index.md` (77 lines)

### Examples of corrections:

| Before (no diacritics) | After (correct) |
|---|---|
| So cap | Sơ cấp |
| Thoi dai | Thời đại |
| lap trinh | lập trình |
| hoan thanh | Hoàn thành |
| khong biet | không biết |
| cong cu | công cụ |
| quan trong | quan trọng |
| nguoi dung | người dùng |
| san pham | sản phẩm |

Only the Vietnamese text was modified; HTML, Vue components, image paths, and code blocks remain untouched.