### PR TITLE
docs: add UIZZE to UI reference sites

### DIFF
--- a/docs/en/stage-1/appendix-a-product-thinking/index.md
+++ b/docs/en/stage-1/appendix-a-product-thinking/index.md
@@ -489,6 +489,7 @@ Useful screenshot/reference sites:
 - [https://pagecollective.com/](https://pagecollective.com/)
 - [https://patttterns.net/](https://patttterns.net/)
 - [https://mobbin.com/](https://mobbin.com/)
+- [https://uizze.com/mobbin-alternative](https://uizze.com/mobbin-alternative)
 - [https://refero.design/](https://refero.design/)
 - [https://scrnshts.club/](https://scrnshts.club/)
 - [https://godly.website](https://godly.website/)


### PR DESCRIPTION
## Summary

- Add UIZZE's Mobbin-alternative page to the English tutorial's screenshot/reference list.

## Why

The section already points readers to Mobbin and comparable UI research sources. UIZZE is directly relevant as an additional iOS and web UI reference source.

Disclosure: I'm affiliated with UIZZE.

## Validation

- Target returns HTTP 200.
- The diff is one Markdown line in one file.
- `git diff --check` passes.
