### PR TITLE
fix(book): include all pages in PDF by default

### DIFF
--- a/scripts/build-latex-book.mjs
+++ b/scripts/build-latex-book.mjs
@@ -79,7 +79,9 @@ const isRtl = locale === 'ar-sa'
 const pdfVersion = bookVersion
 const pdfVersionLabel = versionLabel(pdfVersion)
 const pdfVersionFile = String(pdfVersion).replace(/^v/i, '')
-const sourcePageLimit = Math.max(0, readNumberArg('--limit', 18))
+// Keep the production book complete by default; use --limit or PDF_BOOK_LIMIT
+// explicitly when a smaller development build is needed.
+const sourcePageLimit = Math.max(0, readNumberArg('--limit', 0))
 const defaultPdfFileName = `easy-vibe-open-textbook-${locale}-v${pdfVersionFile}.pdf`
 const pdfOutputPath = path.join(
   distDir,


### PR DESCRIPTION
## Summary

- remove the implicit 18-structure-block limit from production PDF builds
- keep `--limit` and `PDF_BOOK_LIMIT` available for intentionally smaller development builds

Fixes #130.

## Validation

- `node --check scripts/build-latex-book.mjs`
- `npm test`
- `npm run lint` (0 errors; existing warnings only)