### PR TITLE
fix: 修复首页 Appendix 区域数据库原理之后卡片图标重复

### DIFF
--- a/docs/.vitepress/theme/components/home/HomeAppendix.vue
+++ b/docs/.vitepress/theme/components/home/HomeAppendix.vue
@@ -5,6 +5,28 @@ import './HomeSection.css'
 
 const t = inject('t')
 
+// 每个附录页面（按链接最后一段 slug）对应一个贴合词意的唯一图标
+const appendixIcons = {
+  'ai-history': '🤖', // AI 进化史
+  'prompt-engineering': '💬', // 提示词工程
+  'llm-principles': '🧠', // 大语言模型
+  'ai-agents': '🦾', // Agent 智能体
+  'javascript-deep-dive': '💻', // 前端基础
+  'frontend-frameworks': '📈', // 前端进化史
+  'backend-layered-architecture': '🏗️', // 后端架构
+  'backend-languages': '⌨️', // 后端语言
+  'database-fundamentals': '🗄️', // 数据库原理
+  'api-intro': '🔌', // API 设计
+  'git-version-control': '🌿', // Git 版本控制
+  'computer-networks': '🌐' // 计算机网络
+}
+
+const appendixIcon = (card) => {
+  const segments = (card.link || '').split('/').filter(Boolean)
+  const slug = (segments[segments.length - 1] || '').replace(/\.html$/, '')
+  return appendixIcons[slug] || '📚'
+}
+
 const appendixWrapper = ref(null)
 const totalPages = ref(1)
 const currentPage = ref(0)
@@ -94,9 +116,7 @@ onUnmounted(() => {
           :href="withBase(card.link)"
           class="appendix-card"
         >
-          <span class="appendix-emoji">{{
-            ['🤖', '🧠', '🎨', '🚀', '⚙️', '💾', '🛠️', '🌐'][index] || '📚'
-          }}</span>
+          <span class="appendix-emoji">{{ appendixIcon(card) }}</span>
           <span class="appendix-title">{{ card.title }}</span>
         </a>
       </div>


### PR DESCRIPTION
Closes #136

## 问题

首页最下方的 **Appendix · 附录** 横向卡片区，前 8 张卡片各有不同的 emoji 图标，但从第 9 张「数据库原理」开始，「API 设计」「Git 版本控制」「计算机网络」**全部显示同一个 📚 图标**。

原因：`HomeAppendix.vue` 中图标按下标从固定 8 元素数组取值：

```js
['🤖', '🧠', '🎨', '🚀', '⚙️', '💾', '🛠️', '🌐'][index] || '📚'
```

而附录卡片共 12 张，下标 8~11 全部落入 `'📚'` 兜底。

## 修复方案

改为按卡片链接的 slug 映射到**贴合词意且不重复**的图标：

| 卡片 | 图标 |
| --- | --- |
| AI 进化史 | 🤖 |
| 提示词工程 | 💬 |
| 大语言模型 | 🧠 |
| Agent 智能体 | 🦾 |
| 前端基础 | 💻 |
| 前端进化史 | 📈 |
| 后端架构 | 🏗️ |
| 后端语言 | ⌨️ |
| 数据库原理 | 🗄️ |
| API 设计 | 🔌 |
| Git 版本控制 | 🌿 |
| 计算机网络 | 🌐 |

由于是按链接 slug 匹配，**所有语言**（zh-cn / en 12 张卡片，其他语言 4 张卡片）都能得到与词意一致的图标。

## 变更文件

- `docs/.vitepress/theme/components/home/HomeAppendix.vue`

## 验证

- `npm run build` 全量构建通过（10 个语言组）
