### PR TITLE
Add anti-ui-slop to frontend Skill guides

### DIFF
--- a/docs/en/stage-2/frontend/llm-skills-beautiful/index.md
+++ b/docs/en/stage-2/frontend/llm-skills-beautiful/index.md
@@ -105,6 +105,7 @@ You do not need to invent every style prompt from scratch. Here are some useful 
 | **antigravity-awesome-skills** | Helps avoid generic AI visual patterns | - | [GitHub](https://github.com/sickn33/antigravity-awesome-skills) |
 | **superdesigndev/superdesign** | AI-native UI development tooling | 4.7k | [GitHub](https://github.com/superdesigndev/superdesign) |
 | **anthropics/skills/frontend-design** | Anthropic's official frontend design Skill | - | [GitHub](https://github.com/anthropics/skills) |
+| **uizze/anti-ui-slop** | Free MIT workflow for preventing generic UI with a design contract, required states, and a hard finish gate | - | [GitHub](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) |
 
 > 💡 For more style prompts, see the [Appendix: Style Prompt Cheatsheet](#style-prompts).
 
@@ -210,6 +211,7 @@ Writing style prompts by hand every time is tiring. **Skills** are reusable desi
 | :--- | :--- | :--- |
 | **UI/UX Pro Max** | 67 styles, 96 color systems, 57 font combinations | `npm install -g uipro-cli && uipro init --ai claude` |
 | **frontend-design** | Anthropic official Skill focused on avoiding generic AI aesthetics | `npx skills add anthropics/skills/frontend-design` |
+| **anti-ui-slop** | Prevent generic UI with a design contract, required states, and a hard finish gate; full UIZZE adds live search across 800,000+ real web and iOS screens | `npx skills add https://uizze.com --skill anti-ui-slop` |
 | **SuperDesign** | IDE plugin that generates multiple design variants | Search for `SuperDesign` in the VS Code extension marketplace |
 
 ### 3.2 Install UI/UX Pro Max

--- a/docs/zh-cn/stage-2/frontend/llm-skills-beautiful/index.md
+++ b/docs/zh-cn/stage-2/frontend/llm-skills-beautiful/index.md
@@ -104,6 +104,7 @@ AI 训练数据中有海量的前端代码，而大部分代码都使用一些"�
 | **antigravity-awesome-skills** | 避免通用 AI 审美套路 | - | [GitHub](https://github.com/sickn33/antigravity-awesome-skills) |
 | **superdesigndev/superdesign** | AI 原生 UI 开发工具 | 4.7k | [GitHub](https://github.com/superdesigndev/superdesign) |
 | **anthropics/skills/frontend-design** | Anthropic 官方前端设计 Skill | - | [GitHub](https://github.com/anthropics/skills) |
+| **uizze/anti-ui-slop** | MIT 工作流：用设计契约、必需状态和硬性完成门禁，避免生成千篇一律的界面 | - | [GitHub](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) |
 
 > 💡 更多风格提示词请参考[附录：设计风格提示词速查](#style-prompts)
 
@@ -209,6 +210,7 @@ AI 训练数据中有海量的前端代码，而大部分代码都使用一些"�
 | :--- | :--- | :--- |
 | **UI/UX Pro Max** | 67 种风格、96 种配色、57 种字体组合 | `npm install -g uipro-cli && uipro init --ai claude` |
 | **frontend-design** | Anthropic 官方，避免 AI 审美套路 | `npx skills add anthropics/skills/frontend-design` |
+| **anti-ui-slop** | 用设计契约、必需状态和硬性完成门禁避免通用 UI；完整 UIZZE 可在 800,000+ 个真实 Web 和 iOS 界面中进行实时搜索 | `npx skills add https://uizze.com --skill anti-ui-slop` |
 | **SuperDesign** | IDE 插件，生成多个设计变体 | VSCode 扩展市场搜索 "SuperDesign" |
 
 ### 3.2 安装 UI/UX Pro Max（最推荐）


### PR DESCRIPTION
Adds the free UIZZE anti-ui-slop workflow to the English and Simplified Chinese frontend skill guides, with the canonical install command and a distinction between the free skill and optional reference search.

The two resource descriptions now omit the unqualified MIT claim requested in review. The linked package includes material under multiple licenses; this course entry describes the free workflow without interpreting those licenses.

Affiliation: I maintain UIZZE.

Validation: both language tables updated together; git diff --check passes; no runtime or build configuration changes.
